### PR TITLE
feat: Clear Viz Engines in GFX Clear

### DIFF
--- a/src/tv2_afvd_showstyle/getRundown.ts
+++ b/src/tv2_afvd_showstyle/getRundown.ts
@@ -755,7 +755,8 @@ function getGlobalAdLibPiecesAFKD(context: NotesContext, config: BlueprintConfig
 					layer: GraphicLLayer.GraphicLLayerAdLibs,
 					content: {
 						deviceType: DeviceType.VIZMSE,
-						type: TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS
+						type: TimelineContentTypeVizMSE.CLEAR_ALL_ELEMENTS,
+						channelsToSendCommands: ['OVL1', 'FULL1', 'WALL1']
 					}
 				})
 			])


### PR DESCRIPTION
This PR adds support for sending custom commands to Viz Engines in order to fully clear them.
Names of channels that need to be cleared are added in `channelsToSendCommands` of `TimelineObjVIZMSEClearAllElements` in the _GFX Clear_ AdLib.

It depends on https://github.com/olzzon/tv-automation-state-timeline-resolver/pull/14