### PR TITLE
feat: Use JSON config entry and validate

### DIFF
--- a/src/tv2-common/content/dve.ts
+++ b/src/tv2-common/content/dve.ts
@@ -203,7 +203,21 @@ export function MakeContentDVE2<
 	partDefinition?: PartDefinition,
 	offtube?: boolean
 ): { content: SplitsContent; valid: boolean; stickyLayers: string[] } {
-	const template: DVEConfig = JSON.parse(dveConfig.DVEJSON as string) as DVEConfig
+	let template: DVEConfig
+	try {
+		template = JSON.parse(dveConfig.DVEJSON) as DVEConfig
+	} catch (e) {
+		context.warning(`DVE Config JSON is not valid for ${dveConfig.DVEName}`)
+		return {
+			valid: false,
+			content: {
+				boxSourceConfiguration: [],
+				timelineObjects: [],
+				dveConfiguration: []
+			},
+			stickyLayers: []
+		}
+	}
 
 	const inputs = dveConfig.DVEInputs
 		? dveConfig.DVEInputs.toString().split(';')
@@ -438,9 +452,15 @@ export function MakeContentDVE2<
 	})
 
 	const graphicsTemplateName = dveConfig.DVEGraphicsTemplate ? dveConfig.DVEGraphicsTemplate.toString() : ''
-	const graphicsTemplateStyle = dveConfig.DVEGraphicsTemplateJSON
-		? JSON.parse(dveConfig.DVEGraphicsTemplateJSON.toString())
-		: ''
+	let graphicsTemplateStyle: any = ''
+	try {
+		if (dveConfig.DVEGraphicsTemplateJSON) {
+			graphicsTemplateStyle = JSON.parse(dveConfig.DVEGraphicsTemplateJSON.toString())
+		}
+	} catch {
+		context.warning(`DVE Graphics Template JSON is not valid for ${dveConfig.DVEName}`)
+	}
+
 	const keyFile = dveConfig.DVEGraphicsKey ? dveConfig.DVEGraphicsKey.toString() : ''
 	const frameFile = dveConfig.DVEGraphicsFrame ? dveConfig.DVEGraphicsFrame.toString() : ''
 

--- a/src/tv2-common/cues/dve.ts
+++ b/src/tv2-common/cues/dve.ts
@@ -3,9 +3,15 @@ import { DVEConfigInput } from '../helpers'
 
 /**
  * Check that a template string is valid.
- * @param template User-provided template.
+ * @param templateRaw User-provided template.
  */
-export function TemplateIsValid(template: any): boolean {
+export function TemplateIsValid(templateRaw: string): boolean {
+	let template: any
+	try {
+		template = JSON.parse(templateRaw)
+	} catch (e) {
+		return false
+	}
 	let boxesValid = false
 	let indexValid = false
 	let propertiesValid = false

--- a/src/tv2_afvd_showstyle/config-manifests.ts
+++ b/src/tv2_afvd_showstyle/config-manifests.ts
@@ -59,7 +59,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 				id: 'DVEJSON',
 				name: 'DVE config',
 				description: 'DVE config pulled from ATEM',
-				type: ConfigManifestEntryType.STRING,
+				type: ConfigManifestEntryType.JSON,
 				required: true,
 				defaultVal: '',
 				rank: 2
@@ -77,7 +77,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 				id: 'DVEGraphicsTemplateJSON',
 				name: 'CasparCG template config',
 				description: 'Position (and style) data for the boxes in the CasparCG template',
-				type: ConfigManifestEntryType.STRING,
+				type: ConfigManifestEntryType.JSON,
 				required: true,
 				defaultVal: '',
 				rank: 4

--- a/src/tv2_afvd_showstyle/config-manifests.ts
+++ b/src/tv2_afvd_showstyle/config-manifests.ts
@@ -61,7 +61,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 				description: 'DVE config pulled from ATEM',
 				type: ConfigManifestEntryType.JSON,
 				required: true,
-				defaultVal: '',
+				defaultVal: '{}',
 				rank: 2
 			},
 			{
@@ -79,7 +79,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 				description: 'Position (and style) data for the boxes in the CasparCG template',
 				type: ConfigManifestEntryType.JSON,
 				required: true,
-				defaultVal: '',
+				defaultVal: '{}',
 				rank: 4
 			},
 			{

--- a/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
@@ -56,7 +56,7 @@ export function EvaluateAdLib(
 			return
 		}
 
-		if (!TemplateIsValid(JSON.parse(rawTemplate.DVEJSON as string))) {
+		if (!TemplateIsValid(rawTemplate.DVEJSON)) {
 			context.warning(`Invalid DVE template ${parsedCue.variant}`)
 			return
 		}

--- a/src/tv2_afvd_showstyle/helpers/pieces/dve.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/dve.ts
@@ -39,7 +39,7 @@ export function EvaluateDVE(
 		return
 	}
 
-	if (!TemplateIsValid(JSON.parse(rawTemplate.DVEJSON as string))) {
+	if (!TemplateIsValid(rawTemplate.DVEJSON)) {
 		context.warning(`Invalid DVE template ${parsedCue.template}`)
 		return
 	}

--- a/src/tv2_afvd_studio/helpers/config.ts
+++ b/src/tv2_afvd_studio/helpers/config.ts
@@ -111,6 +111,9 @@ export function applyToConfig(
 				case ConfigManifestEntryType.ENUM:
 					newVal = overrideVal as string
 					break
+				case ConfigManifestEntryType.JSON:
+					newVal = overrideVal as string
+					break
 				case ConfigManifestEntryType.TABLE:
 					newVal = overrideVal as TableConfigItemValue
 					break

--- a/src/tv2_offtube_showstyle/config-manifests.ts
+++ b/src/tv2_offtube_showstyle/config-manifests.ts
@@ -53,7 +53,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 				description: 'DVE config pulled from ATEM',
 				type: ConfigManifestEntryType.JSON,
 				required: true,
-				defaultVal: '',
+				defaultVal: '{}',
 				rank: 2
 			},
 			{
@@ -71,7 +71,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 				description: 'Position (and style) data for the boxes in the CasparCG template',
 				type: ConfigManifestEntryType.JSON,
 				required: true,
-				defaultVal: '',
+				defaultVal: '{}',
 				rank: 4
 			},
 			{

--- a/src/tv2_offtube_showstyle/config-manifests.ts
+++ b/src/tv2_offtube_showstyle/config-manifests.ts
@@ -51,7 +51,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 				id: 'DVEJSON',
 				name: 'DVE config',
 				description: 'DVE config pulled from ATEM',
-				type: ConfigManifestEntryType.STRING,
+				type: ConfigManifestEntryType.JSON,
 				required: true,
 				defaultVal: '',
 				rank: 2
@@ -69,7 +69,7 @@ export const showStyleConfigManifest: ConfigManifestEntry[] = [
 				id: 'DVEGraphicsTemplateJSON',
 				name: 'CasparCG template config',
 				description: 'Position (and style) data for the boxes in the CasparCG template',
-				type: ConfigManifestEntryType.STRING,
+				type: ConfigManifestEntryType.JSON,
 				required: true,
 				defaultVal: '',
 				rank: 4

--- a/src/tv2_offtube_showstyle/cues/OfftubeDVE.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeDVE.ts
@@ -29,7 +29,7 @@ export function OfftubeEvaluateDVE(
 		return
 	}
 
-	if (!TemplateIsValid(JSON.parse(rawTemplate.DVEJSON as string))) {
+	if (!TemplateIsValid(rawTemplate.DVEJSON)) {
 		context.warning(`Invalid DVE template ${parsedCue.template}`)
 		return
 	}

--- a/src/tv2_offtube_studio/helpers/config.ts
+++ b/src/tv2_offtube_studio/helpers/config.ts
@@ -98,6 +98,9 @@ export function applyToConfig(
 				case ConfigManifestEntryType.ENUM:
 					newVal = overrideVal as string
 					break
+				case ConfigManifestEntryType.JSON:
+					newVal = overrideVal as string
+					break
 				case ConfigManifestEntryType.TABLE:
 					newVal = overrideVal as TableConfigItemValue
 					break


### PR DESCRIPTION
This PR adds support for JSON entries in the config. In addition to the validation happening on the UI in core, fields are validated in the blueprints for JSON correctness in order to prevent crashing.

Depends on https://github.com/olzzon/tv-automation-sofie-blueprints-integration/pull/2