### PR TITLE
feat: Add graphics status support

### DIFF
--- a/src/tv2-common/cues/viz.ts
+++ b/src/tv2-common/cues/viz.ts
@@ -58,6 +58,7 @@ export function EvaluateVIZBase<
 					content: literal<GraphicsContent>({
 						fileName,
 						path,
+						ignoreMediaObjectStatus: true,
 						timelineObjects: _.compact<TSR.TSRTimelineObj>([
 							literal<TSR.TimelineObjCCGMedia>({
 								id: '',
@@ -90,6 +91,7 @@ export function EvaluateVIZBase<
 					content: literal<GraphicsContent>({
 						fileName,
 						path,
+						ignoreMediaObjectStatus: true,
 						timelineObjects: _.compact<TSR.TSRTimelineObj>([
 							literal<TSR.TimelineObjCCGMedia>({
 								id: '',
@@ -183,6 +185,7 @@ export function EvaluateVIZBase<
 							content: literal<GraphicsContent>({
 								fileName: path,
 								path,
+								ignoreMediaObjectStatus: true,
 								timelineObjects: _.compact<TSR.TSRTimelineObj>([
 									literal<TSR.TimelineObjVIZMSEElementInternal>({
 										id: '',
@@ -215,6 +218,7 @@ export function EvaluateVIZBase<
 							content: literal<GraphicsContent>({
 								fileName: path,
 								path,
+								ignoreMediaObjectStatus: true,
 								timelineObjects: _.compact<TSR.TSRTimelineObj>([
 									literal<TSR.TimelineObjVIZMSEElementInternal>({
 										id: '',

--- a/src/tv2_afvd_showstyle/getRundown.ts
+++ b/src/tv2_afvd_showstyle/getRundown.ts
@@ -657,6 +657,7 @@ function getGlobalAdLibPiecesAFKD(context: NotesContext, config: BlueprintConfig
 			content: literal<GraphicsContent>({
 				fileName: 'BG_LOADER_SC',
 				path: 'BG_LOADER_SC',
+				ignoreMediaObjectStatus: true,
 				timelineObjects: _.compact<TSR.TSRTimelineObj>([
 					literal<TSR.TimelineObjVIZMSEElementInternal>({
 						id: '',

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
@@ -96,6 +96,7 @@ describe('grafik piece', () => {
 				content: literal<GraphicsContent>({
 					fileName: 'bund',
 					path: 'bund',
+					ignoreMediaObjectStatus: true,
 					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
@@ -163,6 +164,7 @@ describe('grafik piece', () => {
 				content: literal<GraphicsContent>({
 					fileName: 'bund',
 					path: 'bund',
+					ignoreMediaObjectStatus: true,
 					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
@@ -235,6 +237,7 @@ describe('grafik piece', () => {
 				content: literal<GraphicsContent>({
 					fileName: 'bund',
 					path: 'bund',
+					ignoreMediaObjectStatus: true,
 					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
@@ -309,6 +312,7 @@ describe('grafik piece', () => {
 				content: literal<GraphicsContent>({
 					fileName: 'bund',
 					path: 'bund',
+					ignoreMediaObjectStatus: true,
 					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
@@ -106,6 +106,7 @@ describe('telefon', () => {
 				content: literal<GraphicsContent>({
 					fileName: 'bund',
 					path: 'bund',
+					ignoreMediaObjectStatus: true,
 					timelineObjects: [
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',

--- a/src/tv2_afvd_showstyle/helpers/pieces/design.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/design.ts
@@ -40,6 +40,7 @@ export function EvaluateDesign(
 				content: literal<GraphicsContent>({
 					fileName: parsedCue.design,
 					path: parsedCue.design,
+					ignoreMediaObjectStatus: true,
 					timelineObjects: _.compact<TSR.TSRTimelineObj>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
@@ -72,6 +73,7 @@ export function EvaluateDesign(
 				content: literal<GraphicsContent>({
 					fileName: parsedCue.design,
 					path: parsedCue.design,
+					ignoreMediaObjectStatus: true,
 					timelineObjects: _.compact<TSR.TSRTimelineObj>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',

--- a/src/tv2_afvd_showstyle/helpers/pieces/grafikViz.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/grafikViz.ts
@@ -92,6 +92,7 @@ export function EvaluateGrafikViz(
 				content: literal<GraphicsContent>({
 					fileName: parsedCue.template,
 					path: parsedCue.template,
+					ignoreMediaObjectStatus: true,
 					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
@@ -134,6 +135,7 @@ export function EvaluateGrafikViz(
 			content: literal<GraphicsContent>({
 				fileName: parsedCue.template,
 				path: parsedCue.template,
+				ignoreMediaObjectStatus: true,
 				timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
 					literal<TSR.TimelineObjVIZMSEElementInternal>({
 						id: '',

--- a/src/tv2_afvd_showstyle/helpers/pieces/mos.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/mos.ts
@@ -167,7 +167,7 @@ function GetMosObjContent(
 	adlibrank?: number
 ): GraphicsContent {
 	return literal<GraphicsContent>({
-		fileName: parsedCue.name,
+		fileName: 'PILOT_' + parsedCue.vcpid.toString(),
 		path: parsedCue.vcpid.toString(),
 		timelineObjects: [
 			literal<TSR.TimelineObjVIZMSEElementPilot>({


### PR DESCRIPTION
This PR adds support for statuses of graphics. 
All GraphicsContents except Pilot and Offtube fulls have `ignoreMediaObjectStatus` set to true. Pilot's GraphicsContent have a `fileName` that will match the `mediaId` in MediaObjects.

Depends on https://github.com/olzzon/tv-automation-sofie-blueprints-integration/pull/3