### PR TITLE
fix: Ident piece lifespan

### DIFF
--- a/src/tv2-common/cueTiming.ts
+++ b/src/tv2-common/cueTiming.ts
@@ -79,7 +79,7 @@ export function CreateTimingAdLib(cue: CueDefinitionBase): Pick<IBlueprintAdLibP
 	return result
 }
 
-export function LifeSpan(mode: 'B' | 'S' | 'O', defaultLifespan: PieceLifespan): PieceLifespan {
+export function LifeSpan(mode: 'B' | 'S' | 'O' | undefined, defaultLifespan: PieceLifespan): PieceLifespan {
 	switch (mode) {
 		case 'B':
 			return PieceLifespan.WithinPart

--- a/src/tv2_afvd_showstyle/helpers/pieces/grafikViz.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/grafikViz.ts
@@ -210,7 +210,7 @@ export function GetInfiniteModeForGrafik(
 		: isTlf
 		? PieceLifespan.WithinPart
 		: isIdent
-		? PieceLifespan.OutOnSegmentEnd
+		? LifeSpan(parsedCue.end?.infiniteMode, PieceLifespan.WithinPart)
 		: parsedCue.end && parsedCue.end.infiniteMode
 		? LifeSpan(parsedCue.end.infiniteMode, PieceLifespan.WithinPart)
 		: FindInfiniteModeFromConfig(config, parsedCue)

--- a/src/tv2_offtube_showstyle/cues/OfftubeGrafikCaspar.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeGrafikCaspar.ts
@@ -505,7 +505,7 @@ export function GetInfiniteModeForGrafik(
 		: isTlf
 		? PieceLifespan.WithinPart
 		: isIdent
-		? PieceLifespan.OutOnSegmentEnd
+		? LifeSpan(parsedCue.end?.infiniteMode, PieceLifespan.WithinPart)
 		: parsedCue.end && parsedCue.end.infiniteMode
 		? LifeSpan(parsedCue.end.infiniteMode, PieceLifespan.WithinPart)
 		: FindInfiniteModeFromConfig(config, parsedCue)


### PR DESCRIPTION
This PR fixes how `lifespan` is set for Ident pieces. It was `OutOnSegmentEnd`, now it is `WithinPart` by default, but it can be overwritten by setting outtime in iNews.