### PR TITLE
fix: Ignore LYD where soundbed is not found in config table

### DIFF
--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/lyd.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/lyd.spec.ts
@@ -6,7 +6,7 @@ import {
 	PieceLifespan
 } from '@sofie-automation/blueprints-integration'
 import { CueDefinitionLYD, literal, ParseCue, PartDefinitionKam } from 'tv2-common'
-import { PartType } from 'tv2-constants'
+import { NoteType, PartType } from 'tv2-constants'
 import { SegmentContext } from '../../../../__mocks__/context'
 import { defaultShowStyleConfig, defaultStudioConfig } from '../../../../tv2_afvd_showstyle/__tests__/configs'
 import { StudioConfig } from '../../../../tv2_afvd_studio/helpers/config'
@@ -124,5 +124,49 @@ describe('lyd', () => {
 		)
 
 		expect(pieces[0].lifespan).toEqual(PieceLifespan.WithinPart)
+	})
+
+	test('Lyd not configured', () => {
+		const parsedCue = ParseCue(['LYD=SN_MISSING', ';0.00-0.10'], config) as CueDefinitionLYD
+		const pieces: IBlueprintPiece[] = []
+		const adlibPieces: IBlueprintAdLibPiece[] = []
+		const actions: IBlueprintActionManifest[] = []
+		const mockPart = literal<PartDefinitionKam>({
+			type: PartType.Kam,
+			variant: {
+				name: '1'
+			},
+			externalId: '0001',
+			rawType: 'Kam 1',
+			cues: [],
+			script: '',
+			storyName: '',
+			fields: {},
+			modified: 0,
+			segmentExternalId: ''
+		})
+
+		const context = makeMockContext()
+
+		EvaluateLYD(
+			context,
+			{
+				showStyle: (defaultShowStyleConfig as unknown) as ShowStyleConfig,
+				studio: (defaultStudioConfig as unknown) as StudioConfig,
+				sources: [],
+				mediaPlayers: [],
+				stickyLayers: [],
+				liveAudio: []
+			},
+			pieces,
+			adlibPieces,
+			actions,
+			parsedCue,
+			mockPart
+		)
+
+		expect(pieces.length).toEqual(0)
+		expect(context.getNotes().length).toEqual(1)
+		expect(context.getNotes()[0].type).toEqual(NoteType.WARNING)
 	})
 })

--- a/src/tv2_afvd_showstyle/helpers/pieces/lyd.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/lyd.ts
@@ -30,7 +30,8 @@ export function EvaluateLYD(
 	const stop = !!parsedCue.variant.match(/^[^_]*STOP[^_]*$/i) // TODO: STOP 1 / STOP 2 etc.
 
 	if (!conf && !stop) {
-		context.warning(`LYD ${parsedCue.variant} not configured, using iNews name as file name`)
+		context.warning(`LYD ${parsedCue.variant} not configured`)
+		return
 	}
 
 	const file = conf ? conf.FileName.toString() : parsedCue.variant


### PR DESCRIPTION
Don't generate a piece, generate a warning only.