### PR TITLE
feat: Add PGMCLEAN iNews cue support (Offtube)

### DIFF
--- a/docs/cues.md
+++ b/docs/cues.md
@@ -304,3 +304,20 @@ CueDefinitionAdLib {
     bynavn: ''
 }
 ```
+
+## PgmClean
+
+Effect: Selects what to send to the Clean Pgm AUX on the ATEM.
+
+Example:
+
+```JS
+"PGMCLEAN=LIVE 1"
+```
+
+```JS
+CueDefinitionPgmClean {
+    type: CueType.PgmClean,
+    source: 'LIVE 1', // Possible values: LIVE 1, PGM
+}
+```

--- a/rundowns/offtubes-reference.json
+++ b/rundowns/offtubes-reference.json
@@ -83,10 +83,13 @@
                             "ST4vrt=ON", 
                             "ST4gst=", 
                             ";0.00"
+                        ],
+                        [
+                            "PGMCLEAN=LIVE 1"
                         ]
                     ],
                     "id" : "00000000:00000000:00000000",
-                    "body" : "\r\n<p><pi>KAM CS 3</pi></p>\r\n<p><a idref=\"0\"></a></p>\r\n<p><a idref=\"1\"></a></p>\r\n<p><cc>---load background on DVE------></cc><a idref=\"2\"><cc><------</cc></a></p>\r\n<p><cc>---load background on FULL------></cc><a idref=\"3\"><cc><------</cc></a></p>\r\n<p><cc>---VALG AF STUDIE PRIMÆR--></cc><a idref=\"4\"><cc><--(ST4p, ST2p)</cc></a></p>\r\n<p><cc>--VALG AF STUDIE SEKUNDÆR--></cc><a idref=\"5\"><cc><---(ST4s, ST2s)</cc><tab></tab></a></p>\r\n<p><tab></tab></p>\r\n<p><cc>----all out overlay--></cc><a idref=\"7\"><cc><---</cc></a></p>\r\n<p><cc>---grafik design på overlay------></cc><a idref=\"8\"><cc><------</cc></a></p>\r\n<p></p>\r\n<p><cc>-----slukker mikrofoner--></cc><a idref=\"9\"><cc><-----</cc><tab><tab><tab></tab></tab></tab></a></p>\r\n<p></p>\r\n",
+                    "body" : "\r\n<p><pi>KAM CS 3</pi></p>\r\n<p><a idref=\"0\"></a></p>\r\n<p><a idref=\"1\"></a></p>\r\n<p><cc>---load background on DVE------></cc><a idref=\"2\"><cc><------</cc></a></p>\r\n<p><cc>---load background on FULL------></cc><a idref=\"3\"><cc><------</cc></a></p>\r\n<p><cc>---VALG AF STUDIE PRIMÆR--></cc><a idref=\"4\"><cc><--(ST4p, ST2p)</cc></a></p>\r\n<p><cc>--VALG AF STUDIE SEKUNDÆR--></cc><a idref=\"5\"><cc><---(ST4s, ST2s)</cc><tab></tab></a></p>\r\n<p><tab></tab></p>\r\n<p><cc>----all out overlay--></cc><a idref=\"7\"><cc><---</cc></a></p>\r\n<p><cc>---grafik design på overlay------></cc><a idref=\"8\"><cc><------</cc></a></p>\r\n<p></p>\r\n<p><cc>-----slukker mikrofoner--></cc><a idref=\"9\"><cc><-----</cc><tab><tab><tab></tab></tab></tab></a></p>\r\n<p></p>\r\n<p><a idref=\"10\"></a></p>\r\n",
                     "fileId" : "00000000:00000000:00000000",
                     "identifier" : "00000000"
                 },

--- a/src/tv2-common/evaluateCues.ts
+++ b/src/tv2-common/evaluateCues.ts
@@ -25,6 +25,7 @@ import {
 	CueDefinitionBackgroundLoop,
 	CueDefinitionGraphic,
 	CueDefinitionGraphicDesign,
+	CueDefinitionPgmClean,
 	CueDefinitionRouting,
 	GraphicInternalOrPilot,
 	GraphicIsPilot
@@ -150,6 +151,13 @@ export interface EvaluateCuesShowstyleOptions {
 		partId: string,
 		parsedCue: CueDefinitionClearGrafiks,
 		shouldAdlib: boolean
+	) => void
+	EvaluateCuePgmClean?: (
+		context: SegmentContext,
+		config: TV2BlueprintConfig,
+		pieces: IBlueprintPiece[],
+		partId: string,
+		parsedCue: CueDefinitionPgmClean
 	) => void
 	/** TODO: Profile -> Change the profile as defined in VIZ device settings */
 	EvaluateCueProfile?: () => void
@@ -374,6 +382,11 @@ export function EvaluateCuesBase(
 							partDefinition.externalId,
 							cue
 						)
+					}
+					break
+				case CueType.PgmClean:
+					if (showStyleOptions.EvaluateCuePgmClean) {
+						showStyleOptions.EvaluateCuePgmClean(context, config, pieces, partDefinition.externalId, cue)
 					}
 					break
 				case CueType.UNPAIRED_TARGET:

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -138,6 +138,11 @@ export interface CueDefinitionRouting extends CueDefinitionBase {
 	INP1?: string
 }
 
+export interface CueDefinitionPgmClean extends CueDefinitionBase {
+	type: CueType.PgmClean
+	source: 'PGM' | 'LIVE 1'
+}
+
 export type CueDefinition =
 	| CueDefinitionUnknown
 	| CueDefinitionEkstern
@@ -155,6 +160,7 @@ export type CueDefinition =
 	| CueDefinitionGraphicDesign
 	| CueDefinitionGraphic<GraphicInternalOrPilot>
 	| CueDefinitionRouting
+	| CueDefinitionPgmClean
 
 export function GraphicIsInternal(
 	o: CueDefinitionGraphic<GraphicInternalOrPilot>
@@ -225,6 +231,8 @@ export function ParseCue(cue: UnparsedCue, config: TV2BlueprintConfig): CueDefin
 		return parseLYD(cue)
 	} else if (cue[0].match(/^JINGLE\d+=/i)) {
 		return parseJingle(cue)
+	} else if (cue[0].match(/^PGMCLEAN=/i)) {
+		return parsePgmClean(cue)
 	}
 
 	return literal<CueDefinitionUnknown>({
@@ -719,6 +727,19 @@ function parseAllOut(cue: string[]): CueDefinitionClearGrafiks {
 	}
 
 	return clearCue
+}
+
+export function parsePgmClean(cue: string[]): CueDefinitionPgmClean {
+	const pgmCleanCue: CueDefinitionPgmClean = {
+		type: CueType.PgmClean,
+		source: 'PGM',
+		iNewsCommand: 'PGMCLEAN'
+	}
+	const pgmSource = cue[0].match(/^PGMCLEAN=(.+)$/i)
+	if (pgmSource && pgmSource[1]?.match(/live 1/i)) {
+		pgmCleanCue.source = 'LIVE 1'
+	}
+	return pgmCleanCue
 }
 
 export function isTime(line: string) {

--- a/src/tv2-common/inewsConversion/converters/ParseCue.ts
+++ b/src/tv2-common/inewsConversion/converters/ParseCue.ts
@@ -140,7 +140,7 @@ export interface CueDefinitionRouting extends CueDefinitionBase {
 
 export interface CueDefinitionPgmClean extends CueDefinitionBase {
 	type: CueType.PgmClean
-	source: 'PGM' | 'LIVE 1'
+	source: 'PGM' | string
 }
 
 export type CueDefinition =
@@ -736,8 +736,8 @@ export function parsePgmClean(cue: string[]): CueDefinitionPgmClean {
 		iNewsCommand: 'PGMCLEAN'
 	}
 	const pgmSource = cue[0].match(/^PGMCLEAN=(.+)$/i)
-	if (pgmSource && pgmSource[1]?.match(/live 1/i)) {
-		pgmCleanCue.source = 'LIVE 1'
+	if (pgmSource && pgmSource[1]) {
+		pgmCleanCue.source = pgmSource[1].toString().toUpperCase()
 	}
 	return pgmCleanCue
 }

--- a/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
+++ b/src/tv2-common/inewsConversion/converters/__tests__/cue-parser.spec.ts
@@ -16,6 +16,7 @@ import {
 	CueDefinitionJingle,
 	CueDefinitionLYD,
 	CueDefinitionMic,
+	CueDefinitionPgmClean,
 	CueDefinitionProfile,
 	CueDefinitionTelefon,
 	CueDefinitionUnknown,
@@ -1349,6 +1350,18 @@ describe('Cue parser', () => {
 				type: CueType.Jingle,
 				clip: 'SN_intro_19',
 				iNewsCommand: 'JINGLE'
+			})
+		)
+	})
+
+	test('PGMCLEAN', () => {
+		const cueJingle = ['PGMCLEAN=Live 1']
+		const result = ParseCue(cueJingle, config)
+		expect(result).toEqual(
+			literal<CueDefinitionPgmClean>({
+				type: CueType.PgmClean,
+				source: 'LIVE 1',
+				iNewsCommand: 'PGMCLEAN'
 			})
 		)
 	})

--- a/src/tv2-constants/enums.ts
+++ b/src/tv2-constants/enums.ts
@@ -25,7 +25,8 @@ export enum CueType {
 	BackgroundLoop,
 	GraphicDesign,
 	Graphic,
-	Routing
+	Routing,
+	PgmClean
 }
 
 export const enum PartType {

--- a/src/tv2_offtube_showstyle/cues/OfftubePgmClean.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubePgmClean.ts
@@ -7,9 +7,8 @@ import {
 	TimelineObjectCoreExt,
 	TSR
 } from '@sofie-automation/blueprints-integration'
-import { CueDefinitionPgmClean, FindSourceInfoStrict, literal, SourceInfo } from 'tv2-common'
+import { CueDefinitionPgmClean, FindSourceInfoStrict, literal, SourceInfo, SourceInfoType } from 'tv2-common'
 import { OfftubeAtemLLayer } from '../../tv2_offtube_studio/layers'
-import { AtemSourceIndex } from '../../types/atem'
 import { OfftubeShowstyleBlueprintConfig } from '../helpers/config'
 import { OfftubeSourceLayer } from '../layers'
 
@@ -21,9 +20,31 @@ export function OfftubeEvaluatePgmClean(
 	parsedCue: CueDefinitionPgmClean
 ) {
 	let sourceInfo: SourceInfo | undefined
-	if (parsedCue.source !== 'PGM') {
-		sourceInfo = FindSourceInfoStrict(context, config.sources, SourceLayerType.REMOTE, parsedCue.source)
+	if (parsedCue.source.match(/PGM/i)) {
+		return
 	}
+
+	let sourceType: SourceInfoType | undefined
+	if (parsedCue.source.match(/live/i)) {
+		sourceType = SourceLayerType.REMOTE
+	} else if (parsedCue.source.match(/[k|c]am/i)) {
+		sourceType = SourceLayerType.CAMERA
+	} else if (parsedCue.source.match(/evs/i)) {
+		sourceType = SourceLayerType.LOCAL
+	}
+
+	if (!sourceType) {
+		context.warning(`Invalid source for clean output: ${parsedCue.source}`)
+		return
+	}
+
+	sourceInfo = FindSourceInfoStrict(context, config.sources, sourceType, parsedCue.source)
+
+	if (!sourceInfo) {
+		context.warning(`Invalid source for clean output: ${parsedCue.source}`)
+		return
+	}
+
 	pieces.push(
 		literal<IBlueprintPiece>({
 			externalId: partId,
@@ -45,7 +66,7 @@ export function OfftubeEvaluatePgmClean(
 							deviceType: TSR.DeviceType.ATEM,
 							type: TSR.TimelineContentTypeAtem.AUX,
 							aux: {
-								input: sourceInfo ? sourceInfo.port : AtemSourceIndex.Prg2
+								input: sourceInfo.port
 							}
 						}
 					})

--- a/src/tv2_offtube_showstyle/cues/OfftubePgmClean.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubePgmClean.ts
@@ -1,0 +1,56 @@
+import {
+	BaseContent,
+	IBlueprintPiece,
+	NotesContext,
+	PieceLifespan,
+	SourceLayerType,
+	TimelineObjectCoreExt,
+	TSR
+} from '@sofie-automation/blueprints-integration'
+import { CueDefinitionPgmClean, FindSourceInfoStrict, literal, SourceInfo } from 'tv2-common'
+import { OfftubeAtemLLayer } from '../../tv2_offtube_studio/layers'
+import { AtemSourceIndex } from '../../types/atem'
+import { OfftubeShowstyleBlueprintConfig } from '../helpers/config'
+import { OfftubeSourceLayer } from '../layers'
+
+export function OfftubeEvaluatePgmClean(
+	context: NotesContext,
+	config: OfftubeShowstyleBlueprintConfig,
+	pieces: IBlueprintPiece[],
+	partId: string,
+	parsedCue: CueDefinitionPgmClean
+) {
+	let sourceInfo: SourceInfo | undefined
+	if (parsedCue.source !== 'PGM') {
+		sourceInfo = FindSourceInfoStrict(context, config.sources, SourceLayerType.REMOTE, parsedCue.source)
+	}
+	pieces.push(
+		literal<IBlueprintPiece>({
+			externalId: partId,
+			name: parsedCue.source,
+			enable: {
+				start: 0
+			},
+			outputLayerId: 'aux',
+			sourceLayerId: OfftubeSourceLayer.AuxPgmClean,
+			lifespan: PieceLifespan.OutOnRundownEnd,
+			content: literal<BaseContent>({
+				timelineObjects: literal<TimelineObjectCoreExt[]>([
+					literal<TSR.TimelineObjAtemAUX>({
+						id: '',
+						enable: { while: '1' },
+						priority: 0,
+						layer: OfftubeAtemLLayer.AtemAuxClean,
+						content: {
+							deviceType: TSR.DeviceType.ATEM,
+							type: TSR.TimelineContentTypeAtem.AUX,
+							aux: {
+								input: sourceInfo ? sourceInfo.port : AtemSourceIndex.Prg2
+							}
+						}
+					})
+				])
+			})
+		})
+	)
+}

--- a/src/tv2_offtube_showstyle/helpers/EvaluateCues.ts
+++ b/src/tv2_offtube_showstyle/helpers/EvaluateCues.ts
@@ -14,6 +14,7 @@ import { OfftubeEvaluateGrafikCaspar } from '../cues/OfftubeGrafikCaspar'
 import { OfftubeEvaluateCueBackgroundLoop } from '../cues/OfftubeGraphicBackgroundLoop'
 import { OfftubeEvaluateGraphicDesign } from '../cues/OfftubeGraphicDesign'
 import { OfftubeEvaluateJingle } from '../cues/OfftubeJingle'
+import { OfftubeEvaluatePgmClean } from '../cues/OfftubePgmClean'
 import { OfftubeShowstyleBlueprintConfig } from './config'
 
 export function OfftubeEvaluateCues(
@@ -36,7 +37,8 @@ export function OfftubeEvaluateCues(
 			EvaluateCueEkstern: OfftubeEvaluateEkstern,
 			EvaluateCueGraphic: OfftubeEvaluateGrafikCaspar,
 			EvaluateCueBackgroundLoop: OfftubeEvaluateCueBackgroundLoop,
-			EvaluateCueGraphicDesign: OfftubeEvaluateGraphicDesign
+			EvaluateCueGraphicDesign: OfftubeEvaluateGraphicDesign,
+			EvaluateCuePgmClean: OfftubeEvaluatePgmClean
 		},
 		context,
 		config,

--- a/src/tv2_offtube_showstyle/layers.ts
+++ b/src/tv2_offtube_showstyle/layers.ts
@@ -17,7 +17,8 @@ export enum SourceLayer {
 	PgmContinuity = 'studio0_offtube_continuity',
 
 	// Aux
-	AuxStudioScreen = 'studio0_offtube_aux_studio_screen'
+	AuxStudioScreen = 'studio0_offtube_aux_studio_screen',
+	AuxPgmClean = 'studio0_offtube_aux_pgm_clean'
 }
 
 // tslint:disable-next-line: variable-name

--- a/src/tv2_offtube_showstyle/migrations/sourcelayer-defaults.ts
+++ b/src/tv2_offtube_showstyle/migrations/sourcelayer-defaults.ts
@@ -714,6 +714,25 @@ const AUX: ISourceLayer[] = [
 		isHidden: false,
 		allowDisable: false,
 		onPresenterScreen: false
+	},
+	{
+		_id: OfftubeSourceLayer.AuxPgmClean,
+		_rank: 21,
+		name: 'Pgm Clean',
+		abbreviation: '',
+		type: SourceLayerType.UNKNOWN,
+		exclusiveGroup: '',
+		isRemoteInput: false,
+		isGuestInput: false,
+		activateKeyboardHotkeys: '',
+		clearKeyboardHotkey: '',
+		assignHotkeysToGlobalAdlibs: true,
+		isSticky: false,
+		activateStickyKeyboardHotkey: '',
+		isQueueable: false,
+		isHidden: true,
+		allowDisable: false,
+		onPresenterScreen: false
 	}
 ]
 


### PR DESCRIPTION
Selects what to send to the Clean Pgm AUX output on the ATEM. It's meant to be used in Klar on Air.
Currently only `PGM` and `LIVE 1` are supported, but with small changes in the parsing logic, it could support any source.
If this cue is not provided, the outputs default to `PGM` equivalent.
Example: `PGMCLEAN=LIVE 1`