### PR TITLE
feat: Add audio bed fade cues

### DIFF
--- a/src/tv2-constants/enums.ts
+++ b/src/tv2-constants/enums.ts
@@ -66,6 +66,7 @@ export enum ControlClasses {
 	/** Indicates that a DVE is currently on air */
 	DVEOnAir = 'dve_on_air',
 	ServerOnAir = 'server_on_air',
+	LYDOnAir = 'lyd_on_air',
 	NOLookahead = 'no_lookahead',
 	CopyMediaPlayerSession = 'copy_media_player_session',
 	AbstractLookahead = 'abstract_lookahead'

--- a/src/tv2_afvd_showstyle/getRundown.ts
+++ b/src/tv2_afvd_showstyle/getRundown.ts
@@ -30,14 +30,15 @@ import {
 	SourceInfo,
 	TimelineBlueprintExt
 } from 'tv2-common'
-import { AdlibActionType, AdlibTags, CONSTANTS, TallyTags } from 'tv2-constants'
+import { AdlibActionType, AdlibTags, CONSTANTS, ControlClasses, TallyTags } from 'tv2-constants'
 import * as _ from 'underscore'
 import {
 	AtemLLayer,
 	atemLLayersDSK,
 	CasparLLayer,
 	CasparPlayerClipLoadingLoop,
-	SisyfosLLAyer
+	SisyfosLLAyer,
+	VirtualAbstractLLayer
 } from '../tv2_afvd_studio/layers'
 import { SisyfosChannel, sisyfosChannels } from '../tv2_afvd_studio/sisyfosChannels'
 import { AtemSourceIndex } from '../types/atem'
@@ -1296,9 +1297,22 @@ function getBaseline(config: BlueprintConfig): TSR.TSRTimelineObjBase[] {
 			}
 		}),
 
+		literal<TSR.TimelineObjAbstractAny>({
+			id: 'lyd_baseline',
+			enable: {
+				while: `!.${ControlClasses.LYDOnAir}`
+			},
+			priority: 0,
+			layer: VirtualAbstractLLayer.AudioBedBaseline,
+			content: {
+				deviceType: TSR.DeviceType.ABSTRACT
+			}
+		}),
+
 		literal<TSR.TimelineObjCCGMedia>({
 			id: '',
-			enable: { while: '1' },
+			// Q: Why start 10s? A: It needs to be longer than the longest fade out, a 10s fade out is probably more than we will ever use.
+			enable: { start: '#lyd_baseline.start + 10000', end: `.${ControlClasses.LYDOnAir}` },
 			priority: 0,
 			layer: CasparLLayer.CasparCGLYD,
 			content: {
@@ -1307,38 +1321,7 @@ function getBaseline(config: BlueprintConfig): TSR.TSRTimelineObjBase[] {
 				loop: true,
 				file: 'EMPTY',
 				mixer: {
-					volume: {
-						_value: 0,
-						inTransition: {
-							easing: TSR.Ease.LINEAR,
-							direction: TSR.Direction.LEFT,
-							duration: config.studio.AudioBedSettings.fadeIn
-						},
-						changeTransition: {
-							easing: TSR.Ease.LINEAR,
-							direction: TSR.Direction.LEFT,
-							duration: config.studio.AudioBedSettings.fadeOut
-						},
-						outTransition: {
-							easing: TSR.Ease.LINEAR,
-							direction: TSR.Direction.LEFT,
-							duration: config.studio.AudioBedSettings.fadeOut
-						}
-					}
-				},
-				transitions: {
-					inTransition: {
-						type: TSR.Transition.MIX,
-						easing: TSR.Ease.LINEAR,
-						direction: TSR.Direction.LEFT,
-						duration: config.studio.AudioBedSettings.fadeIn
-					},
-					outTransition: {
-						type: TSR.Transition.MIX,
-						easing: TSR.Ease.LINEAR,
-						direction: TSR.Direction.LEFT,
-						duration: config.studio.AudioBedSettings.fadeOut
-					}
+					volume: 0
 				}
 			}
 		}),

--- a/src/tv2_afvd_studio/layers.ts
+++ b/src/tv2_afvd_studio/layers.ts
@@ -20,7 +20,9 @@ export function RealLLayers(): string[] {
 	)
 }
 
-export enum VirtualAbstractLLayer {}
+export enum VirtualAbstractLLayer {
+	AudioBedBaseline = 'audio_bed_baseline'
+}
 
 export enum AtemLLayer {
 	AtemMEProgram = 'atem_me_program',

--- a/src/tv2_afvd_studio/migrations/mappings-defaults.ts
+++ b/src/tv2_afvd_studio/migrations/mappings-defaults.ts
@@ -597,6 +597,11 @@ export default literal<BlueprintMappings>({
 		device: TSR.DeviceType.ABSTRACT,
 		deviceId: 'abstract0',
 		lookahead: LookaheadMode.NONE
+	}),
+	audio_bed_baseline: literal<TSR.MappingAbstract & BlueprintMapping>({
+		device: TSR.DeviceType.ABSTRACT,
+		deviceId: 'abstract0',
+		lookahead: LookaheadMode.NONE
 	})
 })
 


### PR DESCRIPTION
- Adds support for /LYD=Fade (\d+)/ cues
- Adlib cues will stop soundbed pieces and fade out the soundbed
- Pre-programmed fades will fade out the soundbed that is playing at that point in the script
- Changes soundbeds to OnRundownChange infinites, as these are the only ones that can be interrupted by WithinPart pieces in the same part. This also means the soundbed won't play until taken, which has been requested as the behaviour