### PR TITLE
feat: Add IdleSisyfosLayers config manifest entry (Offtube)

### DIFF
--- a/src/tv2_offtube_showstyle/__tests__/actionExecutionContext.mock.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actionExecutionContext.mock.ts
@@ -72,6 +72,7 @@ const mockStudioConfig: OfftubeStudioConfig = {
 	MaximumPartDuration: 0,
 	DefaultPartDuration: 0,
 	IdleSource: 0,
+	IdleSisyfosLayers: [],
 	FullKeepAliveDuration: 1000,
 	FullGraphicURL: '',
 	ServerPostrollDuration: 5000,

--- a/src/tv2_offtube_studio/__tests__/config-manifest.spec.ts
+++ b/src/tv2_offtube_studio/__tests__/config-manifest.spec.ts
@@ -46,6 +46,7 @@ const blankStudioConfig: OfftubeStudioConfig = {
 	MaximumPartDuration: 0,
 	DefaultPartDuration: 0,
 	IdleSource: 0,
+	IdleSisyfosLayers: [],
 	FullKeepAliveDuration: 0,
 	FullGraphicURL: '',
 	ServerPostrollDuration: 5000,

--- a/src/tv2_offtube_studio/config-manifests.ts
+++ b/src/tv2_offtube_studio/config-manifests.ts
@@ -505,8 +505,8 @@ export const studioConfigManifest: ConfigManifestEntry[] = [
 	},
 	{
 		id: 'IdleSisyfosLayers',
-		name: 'Idle Sisysyfos Layers',
-		description: 'Sisysyfos Layers active (fader on PGM level) when studio is off-air',
+		name: 'Idle Sisyfos Layers',
+		description: 'Sisyfos Layers active (fader on PGM level) when studio is off-air',
 		type: ConfigManifestEntryType.LAYER_MAPPINGS,
 		filters: {
 			deviceTypes: [TSR.DeviceType.SISYFOS]

--- a/src/tv2_offtube_studio/config-manifests.ts
+++ b/src/tv2_offtube_studio/config-manifests.ts
@@ -504,6 +504,18 @@ export const studioConfigManifest: ConfigManifestEntry[] = [
 		defaultVal: 1
 	},
 	{
+		id: 'IdleSisyfosLayers',
+		name: 'Idle Sisysyfos Layers',
+		description: 'Sisysyfos Layers active (fader on PGM level) when studio is off-air',
+		type: ConfigManifestEntryType.LAYER_MAPPINGS,
+		filters: {
+			deviceTypes: [TSR.DeviceType.SISYFOS]
+		},
+		multiple: true,
+		defaultVal: [OfftubeSisyfosLLayer.SisyfosSourceLive_1_Stereo, OfftubeSisyfosLLayer.SisyfosSourceLive_1_Surround],
+		required: false
+	},
+	{
 		id: 'FullKeepAliveDuration',
 		name: 'Full Keep Alive Duration',
 		description: 'How long to keep the old part alive when going to a full',

--- a/src/tv2_offtube_studio/getBaseline.ts
+++ b/src/tv2_offtube_studio/getBaseline.ts
@@ -35,7 +35,7 @@ export function getBaseline(context: IStudioContext): TSR.TSRTimelineObjBase[] {
 			if (sisyfosChannel) {
 				mappedChannels.push({
 					mappedLayer: id,
-					isPgm: sisyfosChannel.isPgm,
+					isPgm: config.studio.IdleSisyfosLayers.includes(id) ? 1 : sisyfosChannel.isPgm,
 					label: sisyfosChannel.label,
 					visible: true
 				})

--- a/src/tv2_offtube_studio/helpers/config.ts
+++ b/src/tv2_offtube_studio/helpers/config.ts
@@ -65,6 +65,7 @@ export interface OfftubeStudioConfig extends TV2StudioConfigBase {
 	CasparPrerollDuration: number
 	FullKeepAliveDuration: number
 	IdleSource: number
+	IdleSisyfosLayers: string[]
 	FullGraphicURL: string
 
 	FullTransitionSettings: {


### PR DESCRIPTION
Allows selecting sisyfos layers for which the channel fader will be up at PGM level in studio baseline. Defaults to LIVE 1 layers to match the `IdleSource` default.