### PR TITLE
feat: open mics on adlib servers (offtube)

### DIFF
--- a/src/tv2-common/actions/actionTypes.ts
+++ b/src/tv2-common/actions/actionTypes.ts
@@ -12,7 +12,8 @@ export interface ActionSelectServerClip extends ActionBase {
 	file: string
 	partDefinition: PartDefinition
 	duration: number
-	vo: boolean
+	voLayer: boolean
+	voLevels: boolean
 	adLibPix: boolean
 }
 

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -362,7 +362,9 @@ function executeActionSelectServerClip<
 	const currentPiece = settings.SelectedAdlibs
 		? context
 				.getPieceInstances('current')
-				.find(p => p.piece.sourceLayerId === (userData.vo ? settings.SourceLayers.VO : settings.SourceLayers.Server))
+				.find(
+					p => p.piece.sourceLayerId === (userData.voLayer ? settings.SourceLayers.VO : settings.SourceLayers.Server)
+				)
 		: undefined
 
 	const basePart = CreatePartServerBase(
@@ -370,7 +372,8 @@ function executeActionSelectServerClip<
 		config,
 		partDefinition,
 		{
-			vo: userData.vo,
+			voLayer: userData.voLayer,
+			voLevels: userData.voLevels,
 			totalWords: 0,
 			totalTime: 0,
 			tapeTime: userData.duration / 1000,
@@ -379,8 +382,8 @@ function executeActionSelectServerClip<
 		},
 		{
 			SourceLayer: {
-				PgmServer: userData.vo ? settings.SourceLayers.VO : settings.SourceLayers.Server,
-				SelectedServer: userData.vo
+				PgmServer: userData.voLayer ? settings.SourceLayers.VO : settings.SourceLayers.Server,
+				SelectedServer: userData.voLayer
 					? settings.SelectedAdlibs.SourceLayer.VO
 					: settings.SelectedAdlibs.SourceLayer.Server
 			},
@@ -465,7 +468,7 @@ function executeActionSelectServerClip<
 	])
 	if (settings.SelectedAdlibs && !currentPiece) {
 		context.stopPiecesOnLayers([
-			userData.vo ? settings.SelectedAdlibs.SourceLayer.VO : settings.SelectedAdlibs.SourceLayer.Server
+			userData.voLayer ? settings.SelectedAdlibs.SourceLayer.VO : settings.SelectedAdlibs.SourceLayer.Server
 		])
 	}
 }

--- a/src/tv2-common/content/server.ts
+++ b/src/tv2-common/content/server.ts
@@ -66,7 +66,7 @@ export function MakeContentServer(
 	config: TV2BlueprintConfig,
 	sourceLayers: MakeContentServerSourceLayers,
 	adLibPix: boolean,
-	vo: boolean,
+	voLevels: boolean,
 	sourceDuration?: number
 ): VTContent {
 	return literal<VTContent>({
@@ -80,7 +80,7 @@ export function MakeContentServer(
 			config,
 			sourceLayers,
 			adLibPix,
-			vo
+			voLevels
 		)
 	})
 }
@@ -93,7 +93,7 @@ function GetServerTimeline(
 	config: TV2BlueprintConfig,
 	sourceLayers: MakeContentServerSourceLayers,
 	adLibPix?: boolean,
-	vo?: boolean
+	voLevels?: boolean
 ) {
 	const serverEnableClass = `.${GetEnableClassForServer(mediaPlayerSessionId)}`
 
@@ -164,7 +164,9 @@ function GetServerTimeline(
 				}
 			})
 		}),
-		...(vo ? [GetSisyfosTimelineObjForCamera(context, config, 'server', sourceLayers.Sisyfos.StudioMicsGroup)] : []),
+		...(voLevels
+			? [GetSisyfosTimelineObjForCamera(context, config, 'server', sourceLayers.Sisyfos.StudioMicsGroup)]
+			: []),
 		...(sourceLayers.ATEM.ServerLookaheadAux
 			? [
 					literal<TSR.TimelineObjAtemAUX & TimelineBlueprintExt>({

--- a/src/tv2-common/getSegment.ts
+++ b/src/tv2-common/getSegment.ts
@@ -198,7 +198,8 @@ export function getSegmentBase<
 				if (showStyleOptions.CreatePartServer) {
 					blueprintParts.push(
 						showStyleOptions.CreatePartServer(context, config, part, {
-							vo: false,
+							voLayer: false,
+							voLevels: false,
 							totalTime,
 							totalWords,
 							tapeTime,
@@ -221,7 +222,8 @@ export function getSegmentBase<
 				if (showStyleOptions.CreatePartServer) {
 					blueprintParts.push(
 						showStyleOptions.CreatePartServer(context, config, part, {
-							vo: true,
+							voLayer: true,
+							voLevels: true,
 							totalTime,
 							totalWords,
 							tapeTime,

--- a/src/tv2-common/parts/server.ts
+++ b/src/tv2-common/parts/server.ts
@@ -27,7 +27,8 @@ interface PieceMetaDataServer {
 }
 
 export interface ServerPartProps {
-	vo: boolean
+	voLayer: boolean
+	voLevels: boolean
 	totalWords: number
 	totalTime: number
 	tapeTime: number
@@ -71,12 +72,14 @@ export function CreatePartServerBase<
 	const sourceDuration =
 		mediaObjectDuration !== undefined ? mediaObjectDuration * 1000 - config.studio.ServerPostrollDuration : undefined
 	const duration =
-		(mediaObjectDuration !== undefined && ((props.vo && props.totalWords <= 0) || !props.vo) && sourceDuration) ||
+		(mediaObjectDuration !== undefined &&
+			((props.voLayer && props.totalWords <= 0) || !props.voLayer) &&
+			sourceDuration) ||
 		props.tapeTime * 1000 ||
 		0
 	const sanitisedScript = partDefinition.script.replace(/\n/g, '').replace(/\r/g, '')
 	const actualDuration =
-		props.vo && props.totalWords > 0
+		props.voLayer && props.totalWords > 0
 			? (sanitisedScript.length / props.totalWords) * (props.totalTime * 1000 - duration) + duration
 			: duration
 
@@ -108,7 +111,8 @@ export function CreatePartServerBase<
 					file,
 					partDefinition,
 					duration: actualDuration,
-					vo: props.vo,
+					voLayer: props.voLayer,
+					voLevels: props.voLevels,
 					adLibPix: props.adLibPix
 				})
 			}),
@@ -131,10 +135,10 @@ export function CreatePartServerBase<
 					}
 				},
 				props.adLibPix,
-				props.vo,
+				props.voLevels,
 				sourceDuration
 			),
-			tags: [GetTagForServerNext(partDefinition.segmentExternalId, file, props.vo)]
+			tags: [GetTagForServerNext(partDefinition.segmentExternalId, file, props.voLayer)]
 		})
 	)
 
@@ -153,7 +157,7 @@ export function CreatePartServerBase<
 				...GetVTContentProperties(config, file, sourceDuration),
 				timelineObjects: CutToServer(mediaPlayerSession, partDefinition, config, layers.AtemLLayer.MEPgm)
 			},
-			tags: [GetTagForServer(partDefinition.segmentExternalId, file, props.vo), TallyTags.SERVER_IS_LIVE]
+			tags: [GetTagForServer(partDefinition.segmentExternalId, file, props.voLayer), TallyTags.SERVER_IS_LIVE]
 		})
 	)
 

--- a/src/tv2-common/pieces/adlibServer.ts
+++ b/src/tv2-common/pieces/adlibServer.ts
@@ -25,7 +25,8 @@ export function CreateAdlibServer<
 	rank: number,
 	partDefinition: PartDefinition,
 	file: string,
-	vo: boolean,
+	voLayer: boolean,
+	voLevels: boolean,
 	sourceLayers: ServerPartLayers,
 	duration: number,
 	tagAsAdlib: boolean
@@ -37,7 +38,8 @@ export function CreateAdlibServer<
 			file,
 			partDefinition,
 			duration,
-			vo,
+			voLayer,
+			voLevels,
 			adLibPix: tagAsAdlib
 		}),
 		userDataManifest: {},
@@ -48,12 +50,12 @@ export function CreateAdlibServer<
 			outputLayerId: 'pgm', // TODO: Enum
 			content: GetVTContentProperties(config, file, duration),
 			tags: [
-				tagAsAdlib || vo ? AdlibTags.OFFTUBE_ADLIB_SERVER : AdlibTags.OFFTUBE_100pc_SERVER,
+				tagAsAdlib || voLayer ? AdlibTags.OFFTUBE_ADLIB_SERVER : AdlibTags.OFFTUBE_100pc_SERVER,
 				AdlibTags.ADLIB_KOMMENTATOR
 			],
-			currentPieceTags: [GetTagForServer(partDefinition.segmentExternalId, file, !!vo)],
-			nextPieceTags: [GetTagForServerNext(partDefinition.segmentExternalId, file, !!vo)],
-			uniquenessId: `${vo ? 'vo' : 'server'}_${partDefinition.storyName}_${file}`
+			currentPieceTags: [GetTagForServer(partDefinition.segmentExternalId, file, !!voLayer)],
+			nextPieceTags: [GetTagForServerNext(partDefinition.segmentExternalId, file, !!voLayer)],
+			uniquenessId: `${voLayer ? 'vo' : 'server'}_${partDefinition.storyName}_${file}`
 		}
 	})
 }

--- a/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/adlib.ts
@@ -55,6 +55,7 @@ export function EvaluateAdLib(
 				partDefinition,
 				file,
 				false,
+				false,
 				{
 					SourceLayer: {
 						PgmServer: SourceLayer.PgmServer,

--- a/src/tv2_afvd_showstyle/parts/server.ts
+++ b/src/tv2_afvd_showstyle/parts/server.ts
@@ -19,8 +19,8 @@ export function CreatePartServer(
 ): BlueprintResultPart {
 	const basePartProps = CreatePartServerBase(context, config, partDefinition, props, {
 		SourceLayer: {
-			PgmServer: props.vo ? SourceLayer.PgmVoiceOver : SourceLayer.PgmServer, // TODO this actually is shared
-			SelectedServer: props.vo ? SourceLayer.SelectedVoiceOver : SourceLayer.SelectedServer
+			PgmServer: props.voLayer ? SourceLayer.PgmVoiceOver : SourceLayer.PgmServer, // TODO this actually is shared
+			SelectedServer: props.voLayer ? SourceLayer.SelectedVoiceOver : SourceLayer.SelectedServer
 		},
 		AtemLLayer: {
 			MEPgm: AtemLLayer.AtemMEProgram

--- a/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actions.spec.ts
@@ -114,7 +114,8 @@ const selectServerClipAction = literal<ActionSelectServerClip>({
 	type: AdlibActionType.SELECT_SERVER_CLIP,
 	file: '01234A',
 	duration: SERVER_DURATION_A,
-	vo: false,
+	voLayer: false,
+	voLevels: false,
 	partDefinition: literal<PartDefinitionUnknown>({
 		type: PartType.Unknown,
 		externalId: CURRENT_PART_EXTERNAL_ID,
@@ -137,7 +138,8 @@ const selectVOClipAction = literal<ActionSelectServerClip>({
 	type: AdlibActionType.SELECT_SERVER_CLIP,
 	file: 'VOVOA',
 	duration: VO_DURATION_A,
-	vo: true,
+	voLayer: true,
+	voLevels: true,
 	partDefinition: literal<PartDefinitionUnknown>({
 		type: PartType.Unknown,
 		externalId: CURRENT_PART_EXTERNAL_ID,

--- a/src/tv2_offtube_showstyle/cues/OfftubeAdlib.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeAdlib.ts
@@ -56,6 +56,7 @@ export function OfftubeEvaluateAdLib(
 				partDefinition,
 				file,
 				false,
+				true,
 				{
 					SourceLayer: {
 						PgmServer: OfftubeSourceLayer.PgmServer,

--- a/src/tv2_offtube_showstyle/parts/OfftubeServer.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeServer.ts
@@ -19,8 +19,8 @@ export function OfftubeCreatePartServer(
 ): BlueprintResultPart {
 	const basePartProps = CreatePartServerBase(context, config, partDefinition, props, {
 		SourceLayer: {
-			PgmServer: props.vo ? OfftubeSourceLayer.PgmVoiceOver : OfftubeSourceLayer.PgmServer, // TODO this actually is shared
-			SelectedServer: props.vo ? OfftubeSourceLayer.SelectedVoiceOver : OfftubeSourceLayer.SelectedServer
+			PgmServer: props.voLayer ? OfftubeSourceLayer.PgmVoiceOver : OfftubeSourceLayer.PgmServer, // TODO this actually is shared
+			SelectedServer: props.voLayer ? OfftubeSourceLayer.SelectedVoiceOver : OfftubeSourceLayer.SelectedServer
 		},
 		AtemLLayer: {
 			MEPgm: OfftubeAtemLLayer.AtemMEClean,
@@ -63,11 +63,12 @@ export function OfftubeCreatePartServer(
 			0,
 			partDefinition,
 			file,
-			props.vo,
+			props.voLayer,
+			props.voLevels,
 			{
 				SourceLayer: {
-					PgmServer: props.vo ? OfftubeSourceLayer.PgmVoiceOver : OfftubeSourceLayer.PgmServer, // TODO this actually is shared
-					SelectedServer: props.vo ? OfftubeSourceLayer.SelectedVoiceOver : OfftubeSourceLayer.SelectedServer
+					PgmServer: props.voLayer ? OfftubeSourceLayer.PgmVoiceOver : OfftubeSourceLayer.PgmServer, // TODO this actually is shared
+					SelectedServer: props.voLayer ? OfftubeSourceLayer.SelectedVoiceOver : OfftubeSourceLayer.SelectedServer
 				},
 				Caspar: {
 					ClipPending: OfftubeCasparLLayer.CasparPlayerClipPending


### PR DESCRIPTION
Task description: When adlibbing server clips, cue ADLIBPIX=SERVER, studio mics should open or stay open.
Refactored to make distinction between VO-layers, which only VO parts and corresponding adlib actions have, and VO-levels which ADLIBPIX servers in offtube have too.