### PR TITLE
fix: send html template data as objects

### DIFF
--- a/src/tv2-common/helpers/graphics/caspar/index.ts
+++ b/src/tv2-common/helpers/graphics/caspar/index.ts
@@ -73,7 +73,7 @@ export function GetPilotGraphicContentCaspar(
 					type: TSR.TimelineContentTypeCasparCg.TEMPLATE,
 					templateType: 'html',
 					name: 'sport-overlay/index',
-					data: `<templateData>${encodeURI(JSON.stringify(templateData))}</templateData>`,
+					data: templateData,
 					useStopCommand: false,
 					mixer: {
 						opacity: 100
@@ -114,13 +114,11 @@ export function CreateHTMLRendererContent(
 		type: TSR.TimelineContentTypeCasparCg.TEMPLATE,
 		templateType: 'html',
 		name: 'sport-overlay/index',
-		data: `<templateData>${encodeURI(
-			JSON.stringify({
-				display: 'program',
-				slots: HTMLTemplateContent(config, mappedTemplate, data),
-				partialUpdate: true
-			})
-		)}</templateData>`,
+		data: {
+			display: 'program',
+			slots: HTMLTemplateContent(config, mappedTemplate, data),
+			partialUpdate: true
+		},
 		useStopCommand: false,
 		mixer: {
 			opacity: 100

--- a/src/tv2-common/helpers/graphics/index.ts
+++ b/src/tv2-common/helpers/graphics/index.ts
@@ -47,18 +47,16 @@ export function CreateGraphicBaseline(config: TV2BlueprintConfig): TSR.TSRTimeli
 						type: TSR.TimelineContentTypeCasparCg.TEMPLATE,
 						templateType: 'html',
 						name: 'sport-overlay/index',
-						data: `<templateData>${encodeURI(
-							JSON.stringify({
-								display: 'program',
-								slots: {
-									[layerToHTMLGraphicSlot[layer]]: {
-										payload: {},
-										display: 'hidden'
-									}
-								},
-								partialUpdate: true
-							})
-						)}</templateData>`,
+						data: {
+							display: 'program',
+							slots: {
+								[layerToHTMLGraphicSlot[layer]]: {
+									payload: {},
+									display: 'hidden'
+								}
+							},
+							partialUpdate: true
+						},
 						useStopCommand: false
 					}
 				})
@@ -75,28 +73,23 @@ export function CreateGraphicBaseline(config: TV2BlueprintConfig): TSR.TSRTimeli
 					type: TSR.TimelineContentTypeCasparCg.TEMPLATE,
 					templateType: 'html',
 					name: 'sport-overlay/index',
-					data: `<templateData>${encodeURI(
-						JSON.stringify({
-							display: 'program',
-							slots: {
-								...[
-									GraphicLLayer.GraphicLLayerOverlayHeadline,
-									GraphicLLayer.GraphicLLayerOverlayIdent,
-									GraphicLLayer.GraphicLLayerOverlayLower,
-									GraphicLLayer.GraphicLLayerOverlayTema,
-									GraphicLLayer.GraphicLLayerOverlayTopt
-								].map(layer => {
-									return {
-										[layerToHTMLGraphicSlot[layer]]: {
-											payload: {},
-											display: 'hidden'
-										}
-									}
-								})
-							},
-							partialUpdate: true
-						})
-					)}</templateData>`,
+					data: {
+						display: 'program',
+						slots: [
+							GraphicLLayer.GraphicLLayerOverlayHeadline,
+							GraphicLLayer.GraphicLLayerOverlayIdent,
+							GraphicLLayer.GraphicLLayerOverlayLower,
+							GraphicLLayer.GraphicLLayerOverlayTema,
+							GraphicLLayer.GraphicLLayerOverlayTopt
+						].reduce((obj: Record<string, any>, layer) => {
+							obj[layerToHTMLGraphicSlot[layer]] = {
+								payload: {},
+								display: 'hidden'
+							}
+							return obj
+						}, {}),
+						partialUpdate: true
+					},
 					useStopCommand: false
 				}
 			}),
@@ -112,13 +105,11 @@ export function CreateGraphicBaseline(config: TV2BlueprintConfig): TSR.TSRTimeli
 					type: TSR.TimelineContentTypeCasparCg.TEMPLATE,
 					templateType: 'html',
 					name: 'sport-overlay/index',
-					data: `<templateData>${encodeURI(
-						JSON.stringify({
-							display: 'program',
-							design: '',
-							partialUpdate: true
-						})
-					)}</templateData>`,
+					data: {
+						display: 'program',
+						design: '',
+						partialUpdate: true
+					},
 					useStopCommand: false
 				}
 			}),
@@ -134,12 +125,10 @@ export function CreateGraphicBaseline(config: TV2BlueprintConfig): TSR.TSRTimeli
 					type: TSR.TimelineContentTypeCasparCg.TEMPLATE,
 					templateType: 'html',
 					name: 'sport-overlay/index',
-					data: `<templateData>${encodeURI(
-						JSON.stringify({
-							display: 'program',
-							slots: {}
-						})
-					)}</templateData>`,
+					data: {
+						display: 'program',
+						slots: {}
+					},
 					useStopCommand: false
 				}
 			})

--- a/src/tv2_offtube_showstyle/cues/OfftubeGraphicDesign.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeGraphicDesign.ts
@@ -82,13 +82,11 @@ function designTimeline(parsedCue: CueDefinitionGraphicDesign): TSR.TSRTimelineO
 				type: TSR.TimelineContentTypeCasparCg.TEMPLATE,
 				templateType: 'html',
 				name: 'sport-overlay/index',
-				data: `<templateData>${encodeURI(
-					JSON.stringify({
-						display: 'program',
-						design: parsedCue.design,
-						partialUpdate: true
-					})
-				)}</templateData>`,
+				data: {
+					display: 'program',
+					design: parsedCue.design,
+					partialUpdate: true
+				},
 				useStopCommand: false
 			}
 		})

--- a/src/tv2_offtube_showstyle/onTimelineGenerate.ts
+++ b/src/tv2_offtube_showstyle/onTimelineGenerate.ts
@@ -105,7 +105,7 @@ export function disableFirstPilotGFXAnimation(
 			const payload = obj2.metaData?.templateData?.slots && obj2.metaData?.templateData?.slots['250_full']?.payload
 			if (obj2.content.type === TSR.TimelineContentTypeCasparCg.TEMPLATE && payload) {
 				payload.noAnimation = true
-				obj2.content.data = `<templateData>${encodeURI(JSON.stringify(obj2.metaData?.templateData))}</templateData>`
+				obj2.content.data = obj2.metaData!.templateData
 			}
 		}
 	}


### PR DESCRIPTION
Allow the TSR to merge/extend the objects, which makes controling one template from multiple mappings possible

Waiting for a TSR/Playout Gateway release