### PR TITLE
Feat: DSK config roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "webpack-cli": "^3.1.2"
   },
   "dependencies": {
-    "@sofie-automation/blueprints-integration": "https://github.com/olzzon/tv-automation-server-core.git#dist_blueprints_integration20210323_1",
+    "@sofie-automation/blueprints-integration": "https://github.com/olzzon/tv-automation-server-core.git#dist_blueprints_integration20210324_1",
     "underscore": "^1.12.0"
   }
 }

--- a/src/tv2-common/actions/executeAction.ts
+++ b/src/tv2-common/actions/executeAction.ts
@@ -156,7 +156,6 @@ export interface ActionExecutionSettings<
 			Next: string
 			ServerLookaheadAUX?: string
 			SSrcDefault: string
-			Effekt: string
 			cutOnclean: boolean
 		}
 	}
@@ -459,7 +458,6 @@ function executeActionSelectServerClip<
 		...part,
 		...CreateEffektForPartBase(context, config, partDefinition, effektPieces, {
 			sourceLayer: settings.SourceLayers.Effekt,
-			atemLayer: settings.LLayer.Atem.Effekt,
 			sisyfosLayer: settings.LLayer.Sisyfos.Effekt,
 			casparLayer: settings.LLayer.Caspar.Effekt
 		})
@@ -1487,7 +1485,6 @@ function executeActionTakeWithTransition<
 				externalId,
 				{
 					sourceLayer: settings.SourceLayers.Effekt,
-					atemLayer: settings.LLayer.Atem.Effekt,
 					casparLayer: settings.LLayer.Caspar.Effekt,
 					sisyfosLayer: settings.LLayer.Sisyfos.Effekt
 				},
@@ -1516,7 +1513,6 @@ function executeActionTakeWithTransition<
 			const pieces: IBlueprintPiece[] = []
 			const partProps = CreateMixForPartInner(pieces, externalId, userData.variant.frames, {
 				sourceLayer: settings.SourceLayers.Effekt,
-				atemLayer: settings.LLayer.Atem.Effekt,
 				casparLayer: settings.LLayer.Caspar.Effekt,
 				sisyfosLayer: settings.LLayer.Sisyfos.Effekt
 			})

--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -89,6 +89,7 @@ export interface TV2StudioConfigBase {
 		PrerollDuration: number
 		OutTransitionDuration: number
 		CutToMediaPlayer: number
+		FullGraphicBackground: number
 	}
 
 	AudioBedSettings: {

--- a/src/tv2-common/blueprintConfig.ts
+++ b/src/tv2-common/blueprintConfig.ts
@@ -8,7 +8,6 @@ import { DVEConfigInput } from './helpers'
 import { SourceInfo } from './sources'
 
 export type MediaPlayerConfig = Array<{ id: string; val: string }>
-export type DSKConfig = { 1: TableConfigItemDSK } & { [num: number]: TableConfigItemDSK }
 
 export interface TableConfigItemBreakers {
 	BreakerName: string
@@ -65,14 +64,9 @@ export interface TV2StudioConfigBase {
 		Default: number
 		SplitArtF: number
 		SplitArtK: number
-		JingleFill: number
-		JingleKey: number
 		DSK: TableConfigItemDSK[]
 	}
-	AtemSettings: {
-		CCGClip: number
-		CCGGain: number
-	}
+	AtemSettings: {}
 	StudioMics: string[]
 	SourcesRM: TableConfigItemSourceMappingWithSisyfosAndKeepAudio[]
 	SourcesFeed: TableConfigItemSourceMappingWithSisyfosAndKeepAudio[]
@@ -110,7 +104,7 @@ export interface TV2StudioBlueprintConfigBase<StudioConfig extends TV2StudioConf
 	mediaPlayers: MediaPlayerConfig // Atem Input Ids
 	liveAudio: string[]
 	stickyLayers: string[]
-	dsk: DSKConfig
+	dsk: TableConfigItemDSK[]
 }
 
 export interface TV2ShowstyleBlueprintConfigBase {

--- a/src/tv2-common/content/dve.ts
+++ b/src/tv2-common/content/dve.ts
@@ -16,7 +16,7 @@ import {
 	DVEConfigInput,
 	DVEParentClass,
 	DVESources,
-	FindFullSourceDSK,
+	FindDSKFullGFX,
 	FindSourceInfoStrict,
 	GetSisyfosTimelineObjForCamera,
 	GetSisyfosTimelineObjForEVS,
@@ -410,7 +410,7 @@ export function MakeContentDVE2<
 					const sourceInfoFull: SourceInfo = {
 						type: SourceLayerType.GRAPHICS,
 						id: 'full',
-						port: FindFullSourceDSK(config).Fill
+						port: FindDSKFullGFX(config).Fill
 					}
 					setBoxSource(num, sourceInfoFull, mappingFrom.source)
 					dveTimeline.push(

--- a/src/tv2-common/content/jingle.ts
+++ b/src/tv2-common/content/jingle.ts
@@ -1,6 +1,8 @@
 import { TimelineObjectCoreExt, TSR, VTContent } from '@sofie-automation/blueprints-integration'
 import { TimeFromFrames } from 'tv2-common'
 import { TV2BlueprintConfig, TV2BlueprintConfigBase, TV2StudioConfigBase } from '../blueprintConfig'
+import { FindDSKJingle } from '../helpers'
+import { AtemLLayerDSK } from '../layers'
 import { TimelineBlueprintExt } from '../onTimelineGenerate'
 import { literal } from '../util'
 
@@ -10,7 +12,6 @@ export interface JingleLayers {
 		PlayerJingleLookahead?: string
 	}
 	ATEM: {
-		DSKJingle: string
 		USKCleanEffekt?: string
 		USKJinglePreview?: string
 	}
@@ -64,6 +65,7 @@ export function CreateJingleContentBase<
 	preMultiplied: boolean
 ) {
 	const fileName = GetJingleFileName(config, file)
+	const jingleDSK = FindDSKJingle(config)
 	return literal<VTContent>({
 		...CreateJingleExpectedMedia(config, file, alphaAtStart, duration, alphaAtEnd),
 		timelineObjects: literal<TimelineObjectCoreExt[]>([
@@ -103,21 +105,21 @@ export function CreateJingleContentBase<
 					start: Number(config.studio.CasparPrerollDuration)
 				},
 				priority: 1,
-				layer: layers.ATEM.DSKJingle,
+				layer: AtemLLayerDSK(jingleDSK.Number),
 				content: {
 					deviceType: TSR.DeviceType.ATEM,
 					type: TSR.TimelineContentTypeAtem.DSK,
 					dsk: {
 						onAir: true,
 						sources: {
-							fillSource: config.studio.AtemSource.JingleFill,
-							cutSource: config.studio.AtemSource.JingleKey
+							fillSource: jingleDSK.Fill,
+							cutSource: jingleDSK.Key
 						},
 						properties: {
 							tie: false,
 							preMultiply: preMultiplied,
-							clip: config.studio.AtemSettings.CCGClip * 10, // input is percents (0-100), atem uses 1-000,
-							gain: config.studio.AtemSettings.CCGGain * 10, // input is percents (0-100), atem uses 1-000,
+							clip: jingleDSK.Clip * 10, // input is percents (0-100), atem uses 1-000,
+							gain: jingleDSK.Gain * 10, // input is percents (0-100), atem uses 1-000,
 							mask: {
 								enabled: false
 							}
@@ -150,13 +152,13 @@ export function CreateJingleContentBase<
 											onAir: false,
 											mixEffectKeyType: 0,
 											flyEnabled: false,
-											fillSource: config.studio.AtemSource.JingleFill,
-											cutSource: config.studio.AtemSource.JingleKey,
+											fillSource: jingleDSK.Fill,
+											cutSource: jingleDSK.Clip,
 											maskEnabled: false,
 											lumaSettings: {
 												preMultiplied,
-												clip: config.studio.AtemSettings.CCGClip * 10, // input is percents (0-100), atem uses 1-000
-												gain: config.studio.AtemSettings.CCGGain * 10 // input is percents (0-100), atem uses 1-000
+												clip: jingleDSK.Clip * 10, // input is percents (0-100), atem uses 1-000
+												gain: jingleDSK.Gain * 10 // input is percents (0-100), atem uses 1-000
 											}
 										}
 									]
@@ -199,13 +201,13 @@ export function CreateJingleContentBase<
 											onAir: true,
 											mixEffectKeyType: 0,
 											flyEnabled: false,
-											fillSource: config.studio.AtemSource.JingleFill,
-											cutSource: config.studio.AtemSource.JingleKey,
+											fillSource: jingleDSK.Fill,
+											cutSource: jingleDSK.Key,
 											maskEnabled: false,
 											lumaSettings: {
 												preMultiplied,
-												clip: config.studio.AtemSettings.CCGClip * 10, // input is percents (0-100), atem uses 1-000
-												gain: config.studio.AtemSettings.CCGGain * 10 // input is percents (0-100), atem uses 1-000
+												clip: jingleDSK.Clip * 10, // input is percents (0-100), atem uses 1-000
+												gain: jingleDSK.Gain * 10 // input is percents (0-100), atem uses 1-000
 											}
 										}
 									]

--- a/src/tv2-common/content/jingle.ts
+++ b/src/tv2-common/content/jingle.ts
@@ -1,8 +1,7 @@
 import { TimelineObjectCoreExt, TSR, VTContent } from '@sofie-automation/blueprints-integration'
 import { TimeFromFrames } from 'tv2-common'
 import { TV2BlueprintConfig, TV2BlueprintConfigBase, TV2StudioConfigBase } from '../blueprintConfig'
-import { FindDSKJingle } from '../helpers'
-import { AtemLLayerDSK } from '../layers'
+import { EnableDSK, FindDSKJingle } from '../helpers'
 import { TimelineBlueprintExt } from '../onTimelineGenerate'
 import { literal } from '../util'
 
@@ -61,8 +60,7 @@ export function CreateJingleContentBase<
 	loadFirstFrame: boolean,
 	duration: number,
 	alphaAtEnd: number,
-	layers: JingleLayers,
-	preMultiplied: boolean
+	layers: JingleLayers
 ) {
 	const fileName = GetJingleFileName(config, file)
 	const jingleDSK = FindDSKJingle(config)
@@ -99,35 +97,7 @@ export function CreateJingleContentBase<
 				  ]
 				: []),
 
-			literal<TSR.TimelineObjAtemDSK>({
-				id: '',
-				enable: {
-					start: Number(config.studio.CasparPrerollDuration)
-				},
-				priority: 1,
-				layer: AtemLLayerDSK(jingleDSK.Number),
-				content: {
-					deviceType: TSR.DeviceType.ATEM,
-					type: TSR.TimelineContentTypeAtem.DSK,
-					dsk: {
-						onAir: true,
-						sources: {
-							fillSource: jingleDSK.Fill,
-							cutSource: jingleDSK.Key
-						},
-						properties: {
-							tie: false,
-							preMultiply: preMultiplied,
-							clip: jingleDSK.Clip * 10, // input is percents (0-100), atem uses 1-000,
-							gain: jingleDSK.Gain * 10, // input is percents (0-100), atem uses 1-000,
-							mask: {
-								enabled: false
-							}
-						}
-					}
-				},
-				classes: ['MIX_MINUS_OVERRIDE_DSK']
-			}),
+			...EnableDSK(config, 'JINGLE', { start: Number(config.studio.CasparPrerollDuration) }),
 
 			...(layers.ATEM.USKJinglePreview
 				? [
@@ -156,7 +126,7 @@ export function CreateJingleContentBase<
 											cutSource: jingleDSK.Clip,
 											maskEnabled: false,
 											lumaSettings: {
-												preMultiplied,
+												preMultiplied: false,
 												clip: jingleDSK.Clip * 10, // input is percents (0-100), atem uses 1-000
 												gain: jingleDSK.Gain * 10 // input is percents (0-100), atem uses 1-000
 											}
@@ -205,7 +175,7 @@ export function CreateJingleContentBase<
 											cutSource: jingleDSK.Key,
 											maskEnabled: false,
 											lumaSettings: {
-												preMultiplied,
+												preMultiplied: false,
 												clip: jingleDSK.Clip * 10, // input is percents (0-100), atem uses 1-000
 												gain: jingleDSK.Gain * 10 // input is percents (0-100), atem uses 1-000
 											}

--- a/src/tv2-common/helpers/abPlayback.ts
+++ b/src/tv2-common/helpers/abPlayback.ts
@@ -8,7 +8,7 @@ import {
 import { AbstractLLayer, MEDIA_PLAYER_AUTO, MediaPlayerClaimType } from 'tv2-constants'
 import * as _ from 'underscore'
 import { TV2BlueprintConfigBase, TV2StudioConfigBase } from '../blueprintConfig'
-import { AbstractLLayerServerEnable } from '../layers'
+import { AbstractLLayerServerEnable, CasparPlayerClip } from '../layers'
 import {
 	MediaPlayerClaim,
 	PieceMetaData,
@@ -23,7 +23,6 @@ export interface SessionToPlayerMap {
 export interface ABSourceLayers {
 	Caspar: {
 		ClipPending: string
-		PlayerClip: (id: number | string) => string
 	}
 	Sisyfos: {
 		ClipPending: string
@@ -290,12 +289,12 @@ function updateObjectsToMediaPlayer<
 		// Mutate each object to the correct player
 		if (obj.content.deviceType === TSR.DeviceType.CASPARCG) {
 			if (obj.layer === sourceLayers.Caspar.ClipPending) {
-				obj.layer = sourceLayers.Caspar.PlayerClip(playerId)
+				obj.layer = CasparPlayerClip(playerId)
 			} else if (obj.lookaheadForLayer === sourceLayers.Caspar.ClipPending) {
 				// This works on the assumption that layer will contain lookaheadForLayer, but not the exact syntax.
 				// Hopefully this will be durable to any potential future core changes
-				obj.layer = (obj.layer + '').replace(obj.lookaheadForLayer.toString(), sourceLayers.Caspar.PlayerClip(playerId))
-				obj.lookaheadForLayer = sourceLayers.Caspar.PlayerClip(playerId)
+				obj.layer = (obj.layer + '').replace(obj.lookaheadForLayer.toString(), CasparPlayerClip(playerId))
+				obj.lookaheadForLayer = CasparPlayerClip(playerId)
 			} else {
 				context.warning(`Moving object to mediaPlayer that probably shouldnt be? (from layer: ${obj.layer})`)
 				// context.warning(obj)

--- a/src/tv2-common/helpers/dsk.ts
+++ b/src/tv2-common/helpers/dsk.ts
@@ -41,6 +41,41 @@ export function GetDSKCount(atemModel: ATEMModel) {
 	}
 }
 
+export function EnableDSK(
+	config: TV2BlueprintConfigBase<TV2StudioConfigBase>,
+	dsk: 'FULL' | 'OVL' | 'JINGLE',
+	enable?: TSR.TSRTimelineObj['enable']
+): TSR.TSRTimelineObj[] {
+	const dskConf =
+		dsk === 'FULL' ? FindDSKFullGFX(config) : dsk === 'OVL' ? FindDSKOverlayGFX(config) : FindDSKJingle(config)
+
+	return [
+		literal<TSR.TimelineObjAtemDSK>({
+			id: '',
+			enable: enable ?? {
+				start: 0
+			},
+			priority: 1,
+			layer: AtemLLayerDSK(dskConf.Number),
+			content: {
+				deviceType: TSR.DeviceType.ATEM,
+				type: TSR.TimelineContentTypeAtem.DSK,
+				dsk: {
+					onAir: true,
+					sources: {
+						fillSource: dskConf.Fill,
+						cutSource: dskConf.Key
+					},
+					properties: {
+						clip: dskConf.Clip * 10,
+						gain: dskConf.Gain * 10
+					}
+				}
+			}
+		})
+	]
+}
+
 export function CreateDSKBaselineAdlibs(
 	config: TV2BlueprintConfigBase<TV2StudioConfigBase>,
 	baseRank: number

--- a/src/tv2-common/helpers/dsk.ts
+++ b/src/tv2-common/helpers/dsk.ts
@@ -205,7 +205,8 @@ export function DSKConfigManifest(defaultVal: TableConfigItemDSK[]) {
 				type: ConfigManifestEntryType.NUMBER,
 				required: true,
 				defaultVal: 1,
-				rank: 0
+				rank: 0,
+				zeroBased: true
 			},
 			{
 				id: 'Fill',

--- a/src/tv2-common/helpers/dsk.ts
+++ b/src/tv2-common/helpers/dsk.ts
@@ -169,8 +169,8 @@ export function CreateDSKBaseline(config: TV2BlueprintConfigBase<TV2StudioConfig
 				dsk: {
 					onAir: dsk.DefaultOn,
 					sources: {
-						fillSource: config.dsk[dsk.Number].Fill,
-						cutSource: config.dsk[dsk.Number].Key
+						fillSource: dsk.Fill,
+						cutSource: dsk.Key
 					},
 					properties: {
 						tie: false,

--- a/src/tv2-common/helpers/dsk.ts
+++ b/src/tv2-common/helpers/dsk.ts
@@ -1,12 +1,242 @@
-import { DSKConfig, TV2BlueprintConfigBase, TV2StudioConfigBase } from '../blueprintConfig'
+import {
+	ConfigManifestEntryTable,
+	ConfigManifestEntryType,
+	IBlueprintAdLibPiece,
+	PieceLifespan,
+	TableConfigItemValue,
+	TSR
+} from '@sofie-automation/blueprints-integration'
+import { AtemLLayerDSK, literal, SourceLayerAtemDSK } from 'tv2-common'
+import { AdlibTags, DSKRoles, SharedOutputLayers } from 'tv2-constants'
+import { ATEMModel } from '../../types/atem'
+import { TV2BlueprintConfigBase, TV2StudioConfigBase } from '../blueprintConfig'
 import { TableConfigItemDSK } from '../types'
 
-export function parseDSK(studioConfig: TV2StudioConfigBase, defaultDSK: TableConfigItemDSK): DSKConfig {
-	const dsk: DSKConfig = { 1: studioConfig.AtemSource.DSK.find(d => d.Number === 1) || defaultDSK }
-	studioConfig.AtemSource.DSK.forEach(d => (dsk[d.Number] = d))
-	return dsk
+export function FindDSKFullGFX(config: TV2BlueprintConfigBase<TV2StudioConfigBase>): TableConfigItemDSK {
+	return FindDSKWithRoles(config, [DSKRoles.FULLGFX])
 }
 
-export function FindFullSourceDSK(config: TV2BlueprintConfigBase<TV2StudioConfigBase>): TableConfigItemDSK {
-	return Object.values(config.dsk).find(dsk => dsk.FullSource) || config.dsk[1]
+export function FindDSKOverlayGFX(config: TV2BlueprintConfigBase<TV2StudioConfigBase>): TableConfigItemDSK {
+	return FindDSKWithRoles(config, [DSKRoles.OVERLAYGFX])
+}
+
+export function FindDSKJingle(config: TV2BlueprintConfigBase<TV2StudioConfigBase>): TableConfigItemDSK {
+	return FindDSKWithRoles(config, [DSKRoles.JINGLE])
+}
+
+function FindDSKWithRoles(config: TV2BlueprintConfigBase<TV2StudioConfigBase>, roles: DSKRoles[]): TableConfigItemDSK {
+	return config.dsk.find(dsk => dsk.Roles.some(role => roles.includes(role))) ?? config.dsk[0]
+}
+
+export function GetDSKCount(atemModel: ATEMModel) {
+	switch (atemModel) {
+		case ATEMModel.CONSTELLATION_8K_8K_MODE:
+			return 2
+		case ATEMModel.CONSTELLATION_8K_UHD_MODE:
+			return 4
+		case ATEMModel.PRODUCTION_STUDIO_4K_2ME:
+			return 2
+		default:
+			return 0
+	}
+}
+
+export function CreateDSKBaselineAdlibs(
+	config: TV2BlueprintConfigBase<TV2StudioConfigBase>,
+	baseRank: number
+): IBlueprintAdLibPiece[] {
+	const adlibItems: IBlueprintAdLibPiece[] = []
+	for (const dsk of config.dsk) {
+		if (dsk.Toggle) {
+			if (dsk.DefaultOn) {
+				adlibItems.push({
+					externalId: `dskoff${dsk.Number}`,
+					name: `DSK ${dsk.Number + 1} OFF`,
+					_rank: baseRank + dsk.Number,
+					sourceLayerId: SourceLayerAtemDSK(dsk.Number),
+					outputLayerId: SharedOutputLayers.SEC,
+					lifespan: PieceLifespan.OutOnRundownEnd,
+					tags: [AdlibTags.ADLIB_STATIC_BUTTON],
+					content: {
+						timelineObjects: [
+							literal<TSR.TimelineObjAtemDSK>({
+								id: '',
+								enable: { while: '1' },
+								priority: 10,
+								layer: AtemLLayerDSK(dsk.Number),
+								content: {
+									deviceType: TSR.DeviceType.ATEM,
+									type: TSR.TimelineContentTypeAtem.DSK,
+									dsk: {
+										onAir: false
+									}
+								}
+							})
+						]
+					}
+				})
+			} else {
+				adlibItems.push({
+					externalId: `dskon${dsk.Number}`,
+					name: `DSK ${dsk.Number + 1} ON`,
+					_rank: baseRank + dsk.Number,
+					sourceLayerId: SourceLayerAtemDSK(dsk.Number),
+					outputLayerId: SharedOutputLayers.SEC,
+					lifespan: PieceLifespan.OutOnRundownEnd,
+					tags: [AdlibTags.ADLIB_STATIC_BUTTON],
+					content: {
+						timelineObjects: [
+							literal<TSR.TimelineObjAtemDSK>({
+								id: '',
+								enable: { while: '1' },
+								priority: 10,
+								layer: AtemLLayerDSK(dsk.Number),
+								content: {
+									deviceType: TSR.DeviceType.ATEM,
+									type: TSR.TimelineContentTypeAtem.DSK,
+									dsk: {
+										onAir: true,
+										sources: {
+											fillSource: dsk.Fill,
+											cutSource: dsk.Key
+										},
+										properties: {
+											tie: false,
+											preMultiply: false,
+											clip: dsk.Clip * 10, // input is percents (0-100), atem uses 1-000,
+											gain: dsk.Gain * 10, // input is percents (0-100), atem uses 1-000,
+											mask: {
+												enabled: false
+											}
+										}
+									}
+								}
+							})
+						]
+					}
+				})
+			}
+		}
+	}
+	return adlibItems
+}
+
+export function CreateDSKBaseline(config: TV2BlueprintConfigBase<TV2StudioConfigBase>): TSR.TSRTimelineObj[] {
+	return config.dsk.map(dsk => {
+		return literal<TSR.TimelineObjAtemDSK>({
+			id: '',
+			enable: { while: '1' },
+			priority: 0,
+			layer: AtemLLayerDSK(dsk.Number),
+			content: {
+				deviceType: TSR.DeviceType.ATEM,
+				type: TSR.TimelineContentTypeAtem.DSK,
+				dsk: {
+					onAir: dsk.DefaultOn,
+					sources: {
+						fillSource: config.dsk[dsk.Number].Fill,
+						cutSource: config.dsk[dsk.Number].Key
+					},
+					properties: {
+						tie: false,
+						preMultiply: false,
+						clip: dsk.Clip * 10, // input is percents (0-100), atem uses 1-000,
+						gain: dsk.Gain * 10, // input is percents (0-100), atem uses 1-000,
+						mask: {
+							enabled: false
+						}
+					}
+				}
+			}
+		})
+	})
+}
+
+export function DSKConfigManifest(defaultVal: TableConfigItemDSK[]) {
+	return literal<ConfigManifestEntryTable>({
+		id: 'AtemSource.DSK',
+		name: 'ATEM DSK',
+		description: 'ATEM Downstream Keyers Fill and Key',
+		type: ConfigManifestEntryType.TABLE,
+		required: false,
+		defaultVal: literal<Array<TableConfigItemDSK & TableConfigItemValue[0]>>(
+			defaultVal.map(dsk => ({ _id: '', ...dsk }))
+		),
+		columns: [
+			{
+				id: 'Number',
+				name: 'Number',
+				description: 'DSK number, starting from 1',
+				type: ConfigManifestEntryType.NUMBER,
+				required: true,
+				defaultVal: 1,
+				rank: 0
+			},
+			{
+				id: 'Fill',
+				name: 'ATEM Fill',
+				description: 'ATEM vision mixer input for DSK Fill',
+				type: ConfigManifestEntryType.NUMBER,
+				required: true,
+				defaultVal: 21,
+				rank: 1
+			},
+			{
+				id: 'Key',
+				name: 'ATEM Key',
+				description: 'ATEM vision mixer input for DSK Key',
+				type: ConfigManifestEntryType.NUMBER,
+				required: true,
+				defaultVal: 34,
+				rank: 2
+			},
+			{
+				id: 'Toggle',
+				name: 'AdLib Toggle',
+				description: 'Make AdLib that toggles the DSK',
+				type: ConfigManifestEntryType.BOOLEAN,
+				required: true,
+				defaultVal: false,
+				rank: 3
+			},
+			{
+				id: 'DefaultOn',
+				name: 'On by default',
+				description: 'Enable the DSK in the baseline',
+				type: ConfigManifestEntryType.BOOLEAN,
+				required: true,
+				defaultVal: false,
+				rank: 4
+			},
+			{
+				id: 'Roles',
+				name: 'DSK Roles',
+				description: 'Which roles this DSK configuration performs',
+				type: ConfigManifestEntryType.SELECT,
+				required: true,
+				multiple: true,
+				options: [DSKRoles.FULLGFX, DSKRoles.OVERLAYGFX, DSKRoles.JINGLE],
+				defaultVal: [],
+				rank: 5
+			},
+			{
+				id: 'Clip',
+				name: 'ATEM Clip',
+				description: 'DSK Clip (0-100)',
+				type: ConfigManifestEntryType.NUMBER,
+				required: true,
+				defaultVal: 50,
+				rank: 6
+			},
+			{
+				id: 'Gain',
+				name: 'ATEM Gain',
+				description: 'DSK Gain (0-100)',
+				type: ConfigManifestEntryType.NUMBER,
+				required: true,
+				defaultVal: 12.5,
+				rank: 7
+			}
+		]
+	})
 }

--- a/src/tv2-common/helpers/graphics/caspar/index.ts
+++ b/src/tv2-common/helpers/graphics/caspar/index.ts
@@ -12,6 +12,7 @@ import {
 } from 'tv2-common'
 import { GraphicEngine, GraphicLLayer } from 'tv2-constants'
 import { GetEnableForGraphic, GetTimelineLayerForGraphic } from '..'
+import { EnableDSK } from '../../dsk'
 import { IsTargetingFull, IsTargetingWall } from '../target'
 import { layerToHTMLGraphicSlot, Slots } from './slotMappings'
 
@@ -100,7 +101,9 @@ function CasparOverlayTimeline(
 			priority: 1,
 			layer: GetTimelineLayerForGraphic(config, mappedTemplate),
 			content: CreateHTMLRendererContent(config, mappedTemplate, { ...parsedCue.graphic.textFields })
-		})
+		}),
+		// Assume DSK is off by default (config table)
+		...EnableDSK(config, 'OVL')
 	]
 }
 

--- a/src/tv2-common/helpers/graphics/pilot/index.ts
+++ b/src/tv2-common/helpers/graphics/pilot/index.ts
@@ -37,6 +37,7 @@ import {
 import { CasparPilotGeneratorSettings, GetPilotGraphicContentCaspar } from '../caspar'
 import { VizPilotGeneratorSettings } from '../viz'
 
+// Work needed, this should be more generic than expecting showstyles to define how to display pilot graphics
 export interface PilotGeneratorSettings {
 	caspar: CasparPilotGeneratorSettings
 	viz: VizPilotGeneratorSettings

--- a/src/tv2-common/helpers/graphics/viz/index.ts
+++ b/src/tv2-common/helpers/graphics/viz/index.ts
@@ -14,6 +14,7 @@ import {
 	TV2BlueprintConfig
 } from 'tv2-common'
 import { GraphicEngine, GraphicLLayer } from 'tv2-constants'
+import { EnableDSK } from '../../dsk'
 
 export interface VizPilotGeneratorSettings {
 	createPilotTimelineForStudio(config: TV2BlueprintConfig, context: NotesContext, adlib: boolean): TSR.TSRTimelineObj[]
@@ -31,7 +32,7 @@ export function GetInternalGraphicContentVIZ(
 		fileName: parsedCue.graphic.template,
 		path: parsedCue.graphic.template,
 		ignoreMediaObjectStatus: true,
-		timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
+		timelineObjects: literal<TSR.TSRTimelineObj[]>([
 			literal<TSR.TimelineObjVIZMSEElementInternal>({
 				id: '',
 				enable: GetEnableForGraphic(config, engine, parsedCue, isIdentGraphic, partDefinition),
@@ -44,7 +45,9 @@ export function GetInternalGraphicContentVIZ(
 					templateData: parsedCue.graphic.textFields,
 					channelName: engine === 'WALL' ? 'WALL1' : 'OVL1' // TODO: TranslateEngine
 				}
-			})
+			}),
+			// Assume DSK is off by default (config table)
+			...EnableDSK(config, 'OVL')
 		])
 	})
 }

--- a/src/tv2-common/layers/sourceLayers.ts
+++ b/src/tv2-common/layers/sourceLayers.ts
@@ -1,8 +1,54 @@
-import { SharedSourceLayers } from 'tv2-constants'
+import { ISourceLayer, SourceLayerType } from '@sofie-automation/blueprints-integration'
+import { ATEMModel } from '../../types/atem'
+import { GetDSKCount } from '../helpers'
+import { literal } from '../util'
 
-export const pgmDSKLayers: { [num: number]: string } = {
-	1: SharedSourceLayers.PgmDSK1,
-	2: SharedSourceLayers.PgmDSK2,
-	3: SharedSourceLayers.PgmDSK3,
-	4: SharedSourceLayers.PgmDSK4
+/**
+ * Get the sourcelayer name for a given DSK.
+ * @param i DSK number (starting from 0)
+ */
+export function SourceLayerAtemDSK(i: number): string {
+	return `studio0_dsk_${i + 1}_cmd`
+}
+
+function GetSourceLayerDefaultsForDSK(i: number): ISourceLayer {
+	return literal<ISourceLayer>({
+		_id: SourceLayerAtemDSK(i),
+		_rank: 22,
+		name: `DSK${i + 1} off`,
+		abbreviation: '',
+		type: SourceLayerType.UNKNOWN,
+		exclusiveGroup: '',
+		isRemoteInput: false,
+		isGuestInput: false,
+		activateKeyboardHotkeys: '',
+		clearKeyboardHotkey: ',',
+		assignHotkeysToGlobalAdlibs: true,
+		isSticky: false,
+		activateStickyKeyboardHotkey: '',
+		isQueueable: false,
+		isHidden: false,
+		allowDisable: false,
+		onPresenterScreen: false
+	})
+}
+
+export function GetDSKSourceLayerNames(atemModel: ATEMModel): string[] {
+	const names: string[] = []
+
+	for (let i = 0; i < GetDSKCount(atemModel); i++) {
+		names.push(SourceLayerAtemDSK(i))
+	}
+
+	return names
+}
+
+export function GetDSKSourceLayerDefaults(atemModel: ATEMModel): ISourceLayer[] {
+	const defaults: ISourceLayer[] = []
+
+	for (let i = 0; i < GetDSKCount(atemModel); i++) {
+		defaults.push(GetSourceLayerDefaultsForDSK(i))
+	}
+
+	return defaults
 }

--- a/src/tv2-common/layers/timelineLayers.ts
+++ b/src/tv2-common/layers/timelineLayers.ts
@@ -43,13 +43,13 @@ export function GetDSKMappingNames(atemModel: ATEMModel): string[] {
 
 export function GetDSKMappings(atemModel: ATEMModel): BlueprintMappings {
 	const base: BlueprintMappings = {}
-	return GetDSKMappingNames(atemModel).reduce((prev, name) => {
+	return GetDSKMappingNames(atemModel).reduce((prev, name, index) => {
 		prev[name] = literal<TSR.MappingAtem & BlueprintMapping>({
 			device: TSR.DeviceType.ATEM,
 			deviceId: 'atem0',
 			lookahead: LookaheadMode.NONE,
 			mappingType: TSR.MappingAtemType.DownStreamKeyer,
-			index: 0 // 0 = DSK1
+			index
 		})
 		return prev
 	}, base)

--- a/src/tv2-common/layers/timelineLayers.ts
+++ b/src/tv2-common/layers/timelineLayers.ts
@@ -1,7 +1,56 @@
+import { BlueprintMapping, BlueprintMappings, LookaheadMode, TSR } from '@sofie-automation/blueprints-integration'
+import { literal } from 'tv2-common'
+import { ATEMModel } from '../../types/atem'
+import { GetDSKCount } from '../helpers'
+
 export function SisyfosEVSSource(i: number | string) {
 	return `sisyfos_source_evs_${i}`
 }
 
 export function AbstractLLayerServerEnable(i: number) {
 	return `server_enable_${i}`
+}
+
+export function CasparPlayerClip(i: number | string) {
+	return `casparcg_player_clip_${i}`
+}
+
+export function CasparPlayerClipLoadingLoop(i: number | string) {
+	return `casparcg_player_clip_${i}_loading_loop`
+}
+
+export function SisyfosPlayerClip(i: number | string) {
+	return `sisyfos_player_clip_${i}`
+}
+
+/**
+ * Created layer mapping name for a DSK
+ * @param i DSK number starting from 0
+ */
+export function AtemLLayerDSK(i: number) {
+	return `atem_dsk_${i + 1}`
+}
+
+export function GetDSKMappingNames(atemModel: ATEMModel): string[] {
+	const names: string[] = []
+
+	for (let i = 0; i < GetDSKCount(atemModel); i++) {
+		names.push(AtemLLayerDSK(i))
+	}
+
+	return names
+}
+
+export function GetDSKMappings(atemModel: ATEMModel): BlueprintMappings {
+	const base: BlueprintMappings = {}
+	return GetDSKMappingNames(atemModel).reduce((prev, name) => {
+		prev[name] = literal<TSR.MappingAtem & BlueprintMapping>({
+			device: TSR.DeviceType.ATEM,
+			deviceId: 'atem0',
+			lookahead: LookaheadMode.NONE,
+			mappingType: TSR.MappingAtemType.DownStreamKeyer,
+			index: 0 // 0 = DSK1
+		})
+		return prev
+	}, base)
 }

--- a/src/tv2-common/migrations/index.ts
+++ b/src/tv2-common/migrations/index.ts
@@ -178,3 +178,17 @@ export function SetConfigTo(versionStr: string, studio: string, id: string, valu
 		}
 	})
 }
+
+export function RemoveConfig(versionStr: string, studio: string, id: string) {
+	return literal<MigrationStepStudio>({
+		id: `config.valueSet.${studio}.${id}`,
+		version: versionStr,
+		canBeRunAutomatically: true,
+		validate: (context: MigrationContextStudio) => {
+			return !!context.getConfig(id)
+		},
+		migrate: (context: MigrationContextStudio) => {
+			context.removeConfig(id)
+		}
+	})
+}

--- a/src/tv2-common/migrations/index.ts
+++ b/src/tv2-common/migrations/index.ts
@@ -7,6 +7,7 @@ import {
 	MigrationStepStudio
 } from '@sofie-automation/blueprints-integration'
 import { TableConfigItemGFXTemplates } from 'tv2-common'
+import _ = require('underscore')
 import { literal } from '../util'
 
 export * from './moveSourcesToTable'
@@ -155,4 +156,25 @@ export function SetLayerNamesToDefaults(
 	}
 
 	return migrations
+}
+
+export function SetConfigTo(versionStr: string, studio: string, id: string, value: any) {
+	return literal<MigrationStepStudio>({
+		id: `config.valueSet.${studio}.${id}`,
+		version: versionStr,
+		canBeRunAutomatically: true,
+		validate: (context: MigrationContextStudio) => {
+			// Optional mappings based on studio settings can be dropped here
+
+			const existing = context.getConfig(id)
+			if (!existing) {
+				return false
+			}
+
+			return !_.isEqual(existing, value)
+		},
+		migrate: (context: MigrationContextStudio) => {
+			context.setConfig(id, value)
+		}
+	})
 }

--- a/src/tv2-common/migrations/index.ts
+++ b/src/tv2-common/migrations/index.ts
@@ -185,7 +185,7 @@ export function RemoveConfig(versionStr: string, studio: string, id: string) {
 		version: versionStr,
 		canBeRunAutomatically: true,
 		validate: (context: MigrationContextStudio) => {
-			return !!context.getConfig(id)
+			return context.getConfig(id) !== undefined
 		},
 		migrate: (context: MigrationContextStudio) => {
 			context.removeConfig(id)

--- a/src/tv2-common/migrations/moveSourcesToTable.ts
+++ b/src/tv2-common/migrations/moveSourcesToTable.ts
@@ -4,6 +4,7 @@ import {
 	TableConfigItemValue
 } from '@sofie-automation/blueprints-integration'
 import { parseMapStr, TableConfigItemSourceMapping, TableConfigItemSourceMappingWithSisyfos } from 'tv2-common'
+import { DSKRoles } from 'tv2-constants'
 import * as _ from 'underscore'
 import { TableConfigItemDSK } from '../types'
 import { literal } from '../util'
@@ -86,7 +87,11 @@ export function MoveClipSourcePath(versionStr: string, studio: string): Migratio
 	return res
 }
 
-export function MoveDSKToTable(versionStr: string, defaultVal: TableConfigItemDSK): MigrationStepStudio {
+export function MoveDSKToTable(
+	versionStr: string,
+	defaultVal: TableConfigItemDSK,
+	rolesForFullDSK: DSKRoles[]
+): MigrationStepStudio {
 	const configName = 'AtemSource.DSK'
 	const res = literal<MigrationStepStudio>({
 		id: `studioConfig.moveDSKToTable`,
@@ -113,7 +118,9 @@ export function MoveDSKToTable(versionStr: string, defaultVal: TableConfigItemDS
 						Key: oldDSK1Key === undefined ? defaultVal.Key : oldDSK1Key,
 						Toggle: defaultVal.Toggle,
 						DefaultOn: defaultVal.DefaultOn,
-						FullSource: defaultVal.FullSource
+						Roles: rolesForFullDSK,
+						Clip: 50,
+						Gain: 12.5
 					})
 				)
 				context.setConfig(configName, table)

--- a/src/tv2-common/onTimelineGenerate.ts
+++ b/src/tv2-common/onTimelineGenerate.ts
@@ -10,6 +10,7 @@ import {
 	TimelinePersistentState,
 	TSR
 } from '@sofie-automation/blueprints-integration'
+import { CasparPlayerClip } from 'tv2-common'
 import { AbstractLLayer, TallyTags } from 'tv2-constants'
 import * as _ from 'underscore'
 import { SisyfosLLAyer } from '../tv2_afvd_studio/layers'
@@ -125,9 +126,7 @@ function processServerLookaheads(
 		}
 
 		return (
-			[sourceLayers.Caspar.ClipPending, sourceLayers.Caspar.PlayerClip(1), sourceLayers.Caspar.PlayerClip(2)].includes(
-				layer
-			) &&
+			[sourceLayers.Caspar.ClipPending, CasparPlayerClip(1), CasparPlayerClip(2)].includes(layer) &&
 			!obj.isLookahead &&
 			resolvedPieces.some(
 				p => p._id === obj.pieceInstanceId && (p as any).partInstanceId === context.currentPartInstance?._id
@@ -165,7 +164,7 @@ function processServerLookaheads(
 		}
 
 		return !(
-			[sourceLayers.Caspar.ClipPending, sourceLayers.Caspar.PlayerClip(1), sourceLayers.Caspar.PlayerClip(2)]
+			[sourceLayers.Caspar.ClipPending, CasparPlayerClip(1), CasparPlayerClip(2)]
 				.map(l => `${l}_lookahead`)
 				.includes(layer) &&
 			obj.isLookahead &&

--- a/src/tv2-common/parts/effekt.ts
+++ b/src/tv2-common/parts/effekt.ts
@@ -9,7 +9,7 @@ import {
 } from '@sofie-automation/blueprints-integration'
 import {
 	ActionTakeWithTransitionVariantMix,
-	AtemLLayerDSK,
+	EnableDSK,
 	GetTagForTransition,
 	literal,
 	PartDefinition,
@@ -20,7 +20,6 @@ import {
 } from 'tv2-common'
 import { SharedOutputLayers } from 'tv2-constants'
 import { TV2BlueprintConfig } from '../blueprintConfig'
-import { FindDSKJingle } from '../helpers'
 
 export function CreateEffektForPartBase(
 	context: NotesContext,
@@ -109,8 +108,6 @@ export function CreateEffektForPartInner<
 		return false
 	}
 
-	const jingleDSK = FindDSKJingle(config)
-
 	const fileName = config.studio.JingleFolder ? `${config.studio.JingleFolder}/${file}` : ''
 
 	pieces.push(
@@ -149,34 +146,7 @@ export function CreateEffektForPartInner<
 							file: fileName
 						}
 					}),
-					literal<TSR.TimelineObjAtemDSK>({
-						id: '',
-						enable: {
-							start: Number(config.studio.CasparPrerollDuration)
-						},
-						priority: 1,
-						layer: AtemLLayerDSK(jingleDSK.Number),
-						content: {
-							deviceType: TSR.DeviceType.ATEM,
-							type: TSR.TimelineContentTypeAtem.DSK,
-							dsk: {
-								onAir: true,
-								sources: {
-									fillSource: jingleDSK.Fill,
-									cutSource: jingleDSK.Key
-								},
-								properties: {
-									tie: false,
-									preMultiply: false,
-									clip: jingleDSK.Clip * 10, // input is percents (0-100), atem uses 1-000,
-									gain: jingleDSK.Gain * 10, // input is percents (0-100), atem uses 1-000,
-									mask: {
-										enabled: false
-									}
-								}
-							}
-						}
-					}),
+					...EnableDSK(config, 'JINGLE', { start: Number(config.studio.CasparPrerollDuration) }),
 					literal<TSR.TimelineObjSisyfosChannel & TimelineBlueprintExt>({
 						id: '',
 						enable: {

--- a/src/tv2-common/parts/effekt.ts
+++ b/src/tv2-common/parts/effekt.ts
@@ -9,6 +9,7 @@ import {
 } from '@sofie-automation/blueprints-integration'
 import {
 	ActionTakeWithTransitionVariantMix,
+	AtemLLayerDSK,
 	GetTagForTransition,
 	literal,
 	PartDefinition,
@@ -19,6 +20,7 @@ import {
 } from 'tv2-common'
 import { SharedOutputLayers } from 'tv2-constants'
 import { TV2BlueprintConfig } from '../blueprintConfig'
+import { FindDSKJingle } from '../helpers'
 
 export function CreateEffektForPartBase(
 	context: NotesContext,
@@ -27,7 +29,6 @@ export function CreateEffektForPartBase(
 	pieces: IBlueprintPiece[],
 	layers: {
 		sourceLayer: string
-		atemLayer: string
 		casparLayer: string
 		sisyfosLayer: string
 	}
@@ -75,7 +76,6 @@ export function CreateEffektForPartInner<
 	externalId: string,
 	layers: {
 		sourceLayer: string
-		atemLayer: string
 		casparLayer: string
 		sisyfosLayer: string
 	},
@@ -108,6 +108,8 @@ export function CreateEffektForPartInner<
 		context.warning(`Could not find file for ${effekt}`)
 		return false
 	}
+
+	const jingleDSK = FindDSKJingle(config)
 
 	const fileName = config.studio.JingleFolder ? `${config.studio.JingleFolder}/${file}` : ''
 
@@ -153,21 +155,21 @@ export function CreateEffektForPartInner<
 							start: Number(config.studio.CasparPrerollDuration)
 						},
 						priority: 1,
-						layer: layers.atemLayer,
+						layer: AtemLLayerDSK(jingleDSK.Number),
 						content: {
 							deviceType: TSR.DeviceType.ATEM,
 							type: TSR.TimelineContentTypeAtem.DSK,
 							dsk: {
 								onAir: true,
 								sources: {
-									fillSource: config.studio.AtemSource.JingleFill,
-									cutSource: config.studio.AtemSource.JingleKey
+									fillSource: jingleDSK.Fill,
+									cutSource: jingleDSK.Key
 								},
 								properties: {
 									tie: false,
 									preMultiply: false,
-									clip: config.studio.AtemSettings.CCGClip * 10, // input is percents (0-100), atem uses 1-000,
-									gain: config.studio.AtemSettings.CCGGain * 10, // input is percents (0-100), atem uses 1-000,
+									clip: jingleDSK.Clip * 10, // input is percents (0-100), atem uses 1-000,
+									gain: jingleDSK.Gain * 10, // input is percents (0-100), atem uses 1-000,
 									mask: {
 										enabled: false
 									}
@@ -210,7 +212,6 @@ export function CreateMixForPartInner(
 	durationInFrames: number,
 	layers: {
 		sourceLayer: string
-		atemLayer: string
 		casparLayer: string
 		sisyfosLayer: string
 	}

--- a/src/tv2-common/types/config.ts
+++ b/src/tv2-common/types/config.ts
@@ -1,3 +1,5 @@
+import { DSKRoles } from 'tv2-constants'
+
 export interface TableConfigItemSourceMapping {
 	SourceName: string
 	AtemSource: number
@@ -13,10 +15,13 @@ export type TableConfigItemSourceMappingWithSisyfosAndKeepAudio = {
 } & TableConfigItemSourceMappingWithSisyfos
 
 export interface TableConfigItemDSK {
+	/** 0-based */
 	Number: number
 	Fill: number
 	Key: number
 	Toggle: boolean
 	DefaultOn: boolean
-	FullSource: boolean
+	Roles: DSKRoles[]
+	Clip: number
+	Gain: number
 }

--- a/src/tv2-constants/enums.ts
+++ b/src/tv2-constants/enums.ts
@@ -140,9 +140,7 @@ export enum AbstractLLayer {
 	AudioBedBaseline = 'audio_bed_baseline'
 }
 
-export enum SharedATEMLLayer {
-	AtemDSKGraphics = 'atem_dsk_graphics'
-}
+export enum SharedATEMLLayer {}
 
 export enum SharedCasparLLayer {
 	CasparCGLYD = 'casparcg_audio_lyd',
@@ -210,11 +208,11 @@ export enum SharedSourceLayers {
 
 	// Other / sec / manus
 	PgmScript = 'studio0_script',
-	PgmAudioBed = 'studio0_audio_bed',
+	PgmAudioBed = 'studio0_audio_bed'
+}
 
-	// DSK toggle
-	PgmDSK1 = 'studio0_dsk_cmd',
-	PgmDSK2 = 'studio0_dsk_2_cmd',
-	PgmDSK3 = 'studio0_dsk_3_cmd',
-	PgmDSK4 = 'studio0_dsk_4_cmd'
+export enum DSKRoles {
+	FULLGFX = 'full_graphics',
+	OVERLAYGFX = 'overlay_graphics',
+	JINGLE = 'jingle'
 }

--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -87,7 +87,6 @@ export const defaultStudioConfig: StudioConfig = {
 		DSK: defaultDSKConfig,
 		SplitArtF: 30,
 		SplitArtK: 32,
-		FullFrameGrafikBackground: 36,
 		Default: 2001,
 		Continuity: 2002
 	},
@@ -115,7 +114,8 @@ export const defaultStudioConfig: StudioConfig = {
 		KeepAliveDuration: 700,
 		PrerollDuration: 2000,
 		OutTransitionDuration: 280,
-		CutToMediaPlayer: 1500
+		CutToMediaPlayer: 1500,
+		FullGraphicBackground: 36
 	},
 	HTMLGraphics: {
 		GraphicURL: '',

--- a/src/tv2_afvd_showstyle/__tests__/configs.ts
+++ b/src/tv2_afvd_showstyle/__tests__/configs.ts
@@ -1,5 +1,5 @@
-import { DSKConfig, literal, parseMapStr } from 'tv2-common'
-import { StudioConfig } from '../../tv2_afvd_studio/helpers/config'
+import { literal, parseMapStr } from 'tv2-common'
+import { defaultDSKConfig, StudioConfig } from '../../tv2_afvd_studio/helpers/config'
 import { ShowStyleConfig } from '../helpers/config'
 import { DefaultBreakerConfig } from './breakerConfigDefault'
 import { DefaultGrafikConfig } from './grafikConfigDefault'
@@ -84,10 +84,7 @@ export const defaultStudioConfig: StudioConfig = {
 	],
 	AtemSource: {
 		MixMinusDefault: 2,
-		DSK: [],
-		ServerC: 28,
-		JingleFill: 6,
-		JingleKey: 31,
+		DSK: defaultDSKConfig,
 		SplitArtF: 30,
 		SplitArtK: 32,
 		FullFrameGrafikBackground: 36,
@@ -101,10 +98,6 @@ export const defaultStudioConfig: StudioConfig = {
 	],
 	ABPlaybackDebugLogging: false,
 	AtemSettings: {
-		VizClip: 50,
-		VizGain: 12.5,
-		CCGClip: 50,
-		CCGGain: 12.5,
 		MP1Baseline: {
 			Clip: 0,
 			Loop: true,
@@ -244,8 +237,4 @@ export const defaultShowStyleConfig: ShowStyleConfig = {
 	],
 	Transitions: [{ Transition: '1' }, { Transition: '2' }],
 	ShowstyleTransition: 'CUT'
-}
-
-export const defaultDSKConfig: DSKConfig = {
-	1: { Number: 1, Key: 0, Fill: 0, Toggle: true, DefaultOn: true, FullSource: true }
 }

--- a/src/tv2_afvd_showstyle/__tests__/layers-check.ts
+++ b/src/tv2_afvd_showstyle/__tests__/layers-check.ts
@@ -8,8 +8,9 @@ import {
 	TSR
 } from '@sofie-automation/blueprints-integration'
 
-import { literal } from 'tv2-common'
+import { GetDSKSourceLayerNames, literal } from 'tv2-common'
 import mappingsDefaults, { getMediaPlayerMappings } from '../../tv2_afvd_studio/migrations/mappings-defaults'
+import { ATEMModel } from '../../types/atem'
 import { getConfig } from '../helpers/config'
 import { SourceLayer } from '../layers'
 import OutputlayerDefaults from '../migrations/outputlayer-defaults'
@@ -27,6 +28,9 @@ export function checkAllLayers(
 	const config = getConfig(context)
 
 	const allSourceLayers: string[] = _.values(SourceLayer)
+		.map(l => l.toString())
+		.concat(GetDSKSourceLayerNames(ATEMModel.CONSTELLATION_8K_UHD_MODE))
+		.sort()
 	const allOutputLayers = _.map(OutputlayerDefaults, m => m._id)
 
 	const allMappings = literal<BlueprintMappings>({

--- a/src/tv2_afvd_showstyle/__tests__/migrations-defaults.spec.ts
+++ b/src/tv2_afvd_showstyle/__tests__/migrations-defaults.spec.ts
@@ -1,4 +1,6 @@
+import { GetDSKSourceLayerNames } from 'tv2-common'
 import * as _ from 'underscore'
+import { ATEMModel } from '../../types/atem'
 
 import { SourceLayer } from '../layers'
 import SourcelayerDefaults from '../migrations/sourcelayer-defaults'
@@ -6,7 +8,10 @@ import SourcelayerDefaults from '../migrations/sourcelayer-defaults'
 describe('Migration Defaults', () => {
 	test('SourcelayerDefaults', () => {
 		const defaultsIds = _.map(SourcelayerDefaults, v => v._id).sort()
-		const layerIds = _.values(SourceLayer).sort()
+		const layerIds = _.values(SourceLayer)
+			.map(l => l.toString())
+			.concat(GetDSKSourceLayerNames(ATEMModel.CONSTELLATION_8K_UHD_MODE))
+			.sort()
 
 		expect(defaultsIds).toEqual(layerIds)
 	})

--- a/src/tv2_afvd_showstyle/actions.ts
+++ b/src/tv2_afvd_showstyle/actions.ts
@@ -45,7 +45,6 @@ export function executeActionAFVD(context: ActionExecutionContext, actionId: str
 					MEClean: AtemLLayer.AtemMEClean,
 					Next: AtemLLayer.AtemAuxLookahead,
 					SSrcDefault: AtemLLayer.AtemSSrcDefault,
-					Effekt: AtemLLayer.AtemDSKEffect,
 					cutOnclean: false
 				}
 			},

--- a/src/tv2_afvd_showstyle/helpers/config.ts
+++ b/src/tv2_afvd_showstyle/helpers/config.ts
@@ -11,12 +11,6 @@ export interface ShowStyleConfig extends TV2ShowstyleBlueprintConfigBase {
 	WipesConfig: TableConfigItemValue
 }
 
-/*
-export function defaultConfig(context: NotesContext): BlueprintConfig {
-	return extendWithShowStyleConfig(context, defaultStudioConfig(context), {})
-}
-*/
-
 export function parseConfig(config: IBlueprintConfig): any {
 	return { showStyle: config }
 }

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/grafikViz.spec.ts
@@ -7,7 +7,7 @@ import {
 	PieceLifespan,
 	TSR
 } from '@sofie-automation/blueprints-integration'
-import { CueDefinitionGraphic, GraphicInternal, literal, PartDefinitionKam } from 'tv2-common'
+import { AtemLLayerDSK, CueDefinitionGraphic, GraphicInternal, literal, PartDefinitionKam } from 'tv2-common'
 import { AbstractLLayer, AdlibTags, CueType, GraphicLLayer, PartType, SharedOutputLayers } from 'tv2-constants'
 import { SegmentContext } from '../../../../__mocks__/context'
 import { BlueprintConfig } from '../../../../tv2_afvd_studio/helpers/config'
@@ -48,6 +48,30 @@ const dummyPart = literal<PartDefinitionKam>({
 	fields: {},
 	modified: 0,
 	segmentExternalId: ''
+})
+
+const dskEnableObj = literal<TSR.TimelineObjAtemDSK>({
+	id: '',
+	enable: {
+		start: 0
+	},
+	priority: 1,
+	layer: AtemLLayerDSK(0),
+	content: {
+		deviceType: TSR.DeviceType.ATEM,
+		type: TSR.TimelineContentTypeAtem.DSK,
+		dsk: {
+			onAir: true,
+			sources: {
+				fillSource: 21,
+				cutSource: 34
+			},
+			properties: {
+				clip: 500,
+				gain: 125
+			}
+		}
+	}
 })
 
 describe('grafik piece', () => {
@@ -98,7 +122,7 @@ describe('grafik piece', () => {
 					fileName: 'bund',
 					path: 'bund',
 					ignoreMediaObjectStatus: true,
-					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
+					timelineObjects: literal<TSR.TSRTimelineObj[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
 							enable: {
@@ -113,7 +137,8 @@ describe('grafik piece', () => {
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1'
 							}
-						})
+						}),
+						dskEnableObj
 					])
 				})
 			})
@@ -165,7 +190,7 @@ describe('grafik piece', () => {
 					fileName: 'bund',
 					path: 'bund',
 					ignoreMediaObjectStatus: true,
-					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
+					timelineObjects: literal<TSR.TSRTimelineObj[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
 							enable: {
@@ -180,7 +205,8 @@ describe('grafik piece', () => {
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1'
 							}
-						})
+						}),
+						dskEnableObj
 					])
 				})
 			}),
@@ -198,7 +224,7 @@ describe('grafik piece', () => {
 					fileName: 'bund',
 					path: 'bund',
 					ignoreMediaObjectStatus: true,
-					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
+					timelineObjects: literal<TSR.TSRTimelineObj[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
 							enable: {
@@ -213,7 +239,8 @@ describe('grafik piece', () => {
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1'
 							}
-						})
+						}),
+						dskEnableObj
 					])
 				})
 			})
@@ -267,7 +294,7 @@ describe('grafik piece', () => {
 					fileName: 'bund',
 					path: 'bund',
 					ignoreMediaObjectStatus: true,
-					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
+					timelineObjects: literal<TSR.TSRTimelineObj[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
 							enable: {
@@ -282,7 +309,8 @@ describe('grafik piece', () => {
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1'
 							}
-						})
+						}),
+						dskEnableObj
 					])
 				})
 			}),
@@ -300,7 +328,7 @@ describe('grafik piece', () => {
 					fileName: 'bund',
 					path: 'bund',
 					ignoreMediaObjectStatus: true,
-					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
+					timelineObjects: literal<TSR.TSRTimelineObj[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
 							enable: {
@@ -315,7 +343,8 @@ describe('grafik piece', () => {
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1'
 							}
-						})
+						}),
+						dskEnableObj
 					])
 				})
 			})
@@ -369,7 +398,7 @@ describe('grafik piece', () => {
 					fileName: 'bund',
 					path: 'bund',
 					ignoreMediaObjectStatus: true,
-					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
+					timelineObjects: literal<TSR.TSRTimelineObj[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
 							enable: {
@@ -384,7 +413,8 @@ describe('grafik piece', () => {
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1'
 							}
-						})
+						}),
+						dskEnableObj
 					])
 				})
 			})
@@ -440,7 +470,7 @@ describe('grafik piece', () => {
 					fileName: 'bund',
 					path: 'bund',
 					ignoreMediaObjectStatus: true,
-					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
+					timelineObjects: literal<TSR.TSRTimelineObj[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
 							enable: {
@@ -455,7 +485,8 @@ describe('grafik piece', () => {
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1'
 							}
-						})
+						}),
+						dskEnableObj
 					])
 				})
 			})
@@ -508,7 +539,7 @@ describe('grafik piece', () => {
 					fileName: 'direkte',
 					path: 'direkte',
 					ignoreMediaObjectStatus: true,
-					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
+					timelineObjects: literal<TSR.TSRTimelineObj[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
 							enable: {
@@ -523,7 +554,8 @@ describe('grafik piece', () => {
 								templateData: ['KØBENHAVN'],
 								channelName: 'OVL1'
 							}
-						})
+						}),
+						dskEnableObj
 					])
 				})
 			}),
@@ -601,7 +633,7 @@ describe('grafik piece', () => {
 					fileName: 'arkiv',
 					path: 'arkiv',
 					ignoreMediaObjectStatus: true,
-					timelineObjects: literal<TSR.TimelineObjVIZMSEAny[]>([
+					timelineObjects: literal<TSR.TSRTimelineObj[]>([
 						literal<TSR.TimelineObjVIZMSEElementInternal>({
 							id: '',
 							enable: {
@@ -616,7 +648,8 @@ describe('grafik piece', () => {
 								templateData: ['unnamed org'],
 								channelName: 'OVL1'
 							}
-						})
+						}),
+						dskEnableObj
 					])
 				})
 			})

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/lyd.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/lyd.spec.ts
@@ -8,12 +8,8 @@ import {
 import { CueDefinitionLYD, EvaluateLYD, literal, ParseCue, PartDefinitionKam } from 'tv2-common'
 import { NoteType, PartType } from 'tv2-constants'
 import { SegmentContext } from '../../../../__mocks__/context'
-import {
-	defaultDSKConfig,
-	defaultShowStyleConfig,
-	defaultStudioConfig
-} from '../../../../tv2_afvd_showstyle/__tests__/configs'
-import { StudioConfig } from '../../../../tv2_afvd_studio/helpers/config'
+import { defaultShowStyleConfig, defaultStudioConfig } from '../../../../tv2_afvd_showstyle/__tests__/configs'
+import { defaultDSKConfig, StudioConfig } from '../../../../tv2_afvd_studio/helpers/config'
 import mappingsDefaults from '../../../../tv2_afvd_studio/migrations/mappings-defaults'
 import { getConfig, ShowStyleConfig } from '../../config'
 

--- a/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/__tests__/telefon.spec.ts
@@ -6,15 +6,21 @@ import {
 	PieceLifespan,
 	TSR
 } from '@sofie-automation/blueprints-integration'
-import { CueDefinitionGraphic, CueDefinitionTelefon, GraphicInternal, literal, PartDefinitionKam } from 'tv2-common'
+import {
+	AtemLLayerDSK,
+	CueDefinitionGraphic,
+	CueDefinitionTelefon,
+	GraphicInternal,
+	literal,
+	PartDefinitionKam
+} from 'tv2-common'
 import { CueType, GraphicLLayer, PartType, SharedOutputLayers } from 'tv2-constants'
 import { SegmentContext } from '../../../../__mocks__/context'
 import { defaultShowStyleConfig, defaultStudioConfig } from '../../../../tv2_afvd_showstyle/__tests__/configs'
 import { SourceLayer } from '../../../../tv2_afvd_showstyle/layers'
-import { StudioConfig } from '../../../../tv2_afvd_studio/helpers/config'
+import { defaultDSKConfig, StudioConfig } from '../../../../tv2_afvd_studio/helpers/config'
 import { SisyfosLLAyer } from '../../../../tv2_afvd_studio/layers'
 import mappingsDefaults from '../../../../tv2_afvd_studio/migrations/mappings-defaults'
-import { AtemSourceIndex } from '../../../../types/atem'
 import { ShowStyleConfig } from '../../config'
 import { EvaluateTelefon } from '../telefon'
 
@@ -78,16 +84,7 @@ describe('telefon', () => {
 				mediaPlayers: [],
 				stickyLayers: [],
 				liveAudio: [],
-				dsk: {
-					1: {
-						Number: 1,
-						Fill: AtemSourceIndex.Col1,
-						Key: AtemSourceIndex.Blk,
-						Toggle: false,
-						DefaultOn: true,
-						FullSource: true
-					}
-				}
+				dsk: defaultDSKConfig
 			},
 			mockContext,
 			pieces,
@@ -125,6 +122,29 @@ describe('telefon', () => {
 								templateName: 'bund',
 								templateData: ['Odense', 'Copenhagen'],
 								channelName: 'OVL1'
+							}
+						}),
+						literal<TSR.TimelineObjAtemDSK>({
+							id: '',
+							enable: {
+								start: 0
+							},
+							priority: 1,
+							layer: AtemLLayerDSK(0),
+							content: {
+								deviceType: TSR.DeviceType.ATEM,
+								type: TSR.TimelineContentTypeAtem.DSK,
+								dsk: {
+									onAir: true,
+									sources: {
+										fillSource: 21,
+										cutSource: 34
+									},
+									properties: {
+										clip: 500,
+										gain: 125
+									}
+								}
 							}
 						}),
 						literal<TSR.TimelineObjSisyfosChannel>({

--- a/src/tv2_afvd_showstyle/helpers/pieces/graphicPilot.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/graphicPilot.ts
@@ -10,7 +10,7 @@ import {
 import {
 	CreatePilotGraphic,
 	CueDefinitionGraphic,
-	FindFullSourceDSK,
+	FindDSKFullGFX,
 	GetSisyfosTimelineObjForCamera,
 	GraphicPilot,
 	literal,
@@ -54,7 +54,7 @@ export function EvaluateCueGraphicPilot(
 }
 
 function makeStudioTimelineViz(config: BlueprintConfig, context: NotesContext, adlib: boolean): TSR.TSRTimelineObj[] {
-	const fullsDSK = FindFullSourceDSK(config)
+	const fullsDSK = FindDSKFullGFX(config)
 
 	return [
 		literal<TSR.TimelineObjAtemME>({

--- a/src/tv2_afvd_showstyle/helpers/pieces/graphicPilot.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/graphicPilot.ts
@@ -10,6 +10,7 @@ import {
 import {
 	CreatePilotGraphic,
 	CueDefinitionGraphic,
+	EnableDSK,
 	FindDSKFullGFX,
 	GetSisyfosTimelineObjForCamera,
 	GraphicPilot,
@@ -54,7 +55,7 @@ export function EvaluateCueGraphicPilot(
 }
 
 function makeStudioTimelineViz(config: BlueprintConfig, context: NotesContext, adlib: boolean): TSR.TSRTimelineObj[] {
-	const fullsDSK = FindDSKFullGFX(config)
+	const fullDSK = FindDSKFullGFX(config)
 
 	return [
 		literal<TSR.TimelineObjAtemME>({
@@ -74,7 +75,7 @@ function makeStudioTimelineViz(config: BlueprintConfig, context: NotesContext, a
 			},
 			...(adlib ? { classes: ['adlib_deparent'] } : {})
 		}),
-		literal<TSR.TimelineObjAtemDSK>({
+		literal<TSR.TimelineObjAtemAUX>({
 			id: '',
 			enable: {
 				start: config.studio.VizPilotGraphics.CutToMediaPlayer
@@ -83,17 +84,15 @@ function makeStudioTimelineViz(config: BlueprintConfig, context: NotesContext, a
 			layer: AtemLLayer.AtemAuxPGM,
 			content: {
 				deviceType: TSR.DeviceType.ATEM,
-				type: TSR.TimelineContentTypeAtem.DSK,
-				dsk: {
-					onAir: true,
-					sources: {
-						fillSource: fullsDSK.Fill,
-						cutSource: fullsDSK.Key
-					}
+				type: TSR.TimelineContentTypeAtem.AUX,
+				aux: {
+					input: fullDSK.Fill
 				}
 			},
 			classes: ['MIX_MINUS_OVERRIDE_DSK', 'PLACEHOLDER_OBJECT_REMOVEME']
 		}),
+		// Assume DSK is off by default (config table)
+		...EnableDSK(config, 'FULL'),
 		GetSisyfosTimelineObjForCamera(context, config, 'full', SisyfosLLAyer.SisyfosGroupStudioMics),
 		...muteSisyfosChannels(config.sources)
 	]

--- a/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
@@ -116,26 +116,17 @@ export function createJingleContentAFVD(
 	duration: number,
 	alphaAtEnd: number
 ) {
-	const content = CreateJingleContentBase(
-		config,
-		file,
-		alphaAtStart,
-		loadFirstFrame,
-		duration,
-		alphaAtEnd,
-		{
-			Caspar: {
-				PlayerJingle: CasparLLayer.CasparPlayerJingle
-			},
-			ATEM: {
-				USKCleanEffekt: AtemLLayer.AtemCleanUSKEffect
-			},
-			Sisyfos: {
-				PlayerJingle: SisyfosLLAyer.SisyfosSourceJingle
-			}
+	const content = CreateJingleContentBase(config, file, alphaAtStart, loadFirstFrame, duration, alphaAtEnd, {
+		Caspar: {
+			PlayerJingle: CasparLLayer.CasparPlayerJingle
 		},
-		false
-	)
+		ATEM: {
+			USKCleanEffekt: AtemLLayer.AtemCleanUSKEffect
+		},
+		Sisyfos: {
+			PlayerJingle: SisyfosLLAyer.SisyfosSourceJingle
+		}
+	})
 
 	return content
 }

--- a/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
+++ b/src/tv2_afvd_showstyle/helpers/pieces/jingle.ts
@@ -128,7 +128,6 @@ export function createJingleContentAFVD(
 				PlayerJingle: CasparLLayer.CasparPlayerJingle
 			},
 			ATEM: {
-				DSKJingle: AtemLLayer.AtemDSKEffect,
 				USKCleanEffekt: AtemLLayer.AtemCleanUSKEffect
 			},
 			Sisyfos: {

--- a/src/tv2_afvd_showstyle/migrations/index.ts
+++ b/src/tv2_afvd_showstyle/migrations/index.ts
@@ -2,6 +2,7 @@ import { MigrationStepShowStyle } from '@sofie-automation/blueprints-integration
 import {
 	AddGraphicToGFXTable,
 	literal,
+	removeSourceLayer,
 	SetShortcutListMigrationStep,
 	SetShowstyleTransitionMigrationStep,
 	UpsertValuesIntoTransitionTable
@@ -90,6 +91,12 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 		OutType: '',
 		IsDesign: false
 	}),
+
+	/**
+	 * 1.6.1
+	 * - Remove studio0_dsk_cmd, will be replaced by studio0_dsk_1_cmd by defaults
+	 */
+	removeSourceLayer('1.6.1', 'AFVD', 'studio0_dsk_cmd'),
 
 	// Fill in any layers that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations

--- a/src/tv2_afvd_showstyle/migrations/sourcelayer-defaults.ts
+++ b/src/tv2_afvd_showstyle/migrations/sourcelayer-defaults.ts
@@ -1,6 +1,7 @@
 import { ISourceLayer, SourceLayerType } from '@sofie-automation/blueprints-integration'
-import { literal } from 'tv2-common'
+import { GetDSKSourceLayerDefaults, literal } from 'tv2-common'
 import { SharedSourceLayers } from 'tv2-constants'
+import { ATEMModel } from '../../types/atem'
 import { SourceLayer } from '../layers'
 
 // OVERLAY group
@@ -544,82 +545,7 @@ const SEC: ISourceLayer[] = [
 		allowDisable: false,
 		onPresenterScreen: false
 	},
-	{
-		_id: SourceLayer.PgmDSK1,
-		_rank: 20,
-		name: 'DSK1 off',
-		abbreviation: '',
-		type: SourceLayerType.UNKNOWN,
-		exclusiveGroup: '',
-		isRemoteInput: false,
-		isGuestInput: false,
-		activateKeyboardHotkeys: ',',
-		clearKeyboardHotkey: ',',
-		assignHotkeysToGlobalAdlibs: true,
-		isSticky: false,
-		activateStickyKeyboardHotkey: '',
-		isQueueable: false,
-		isHidden: false,
-		allowDisable: false,
-		onPresenterScreen: false
-	},
-	{
-		_id: SourceLayer.PgmDSK2,
-		_rank: 21,
-		name: 'DSK2 off',
-		abbreviation: '',
-		type: SourceLayerType.UNKNOWN,
-		exclusiveGroup: '',
-		isRemoteInput: false,
-		isGuestInput: false,
-		activateKeyboardHotkeys: '',
-		clearKeyboardHotkey: ',',
-		assignHotkeysToGlobalAdlibs: true,
-		isSticky: false,
-		activateStickyKeyboardHotkey: '',
-		isQueueable: false,
-		isHidden: false,
-		allowDisable: false,
-		onPresenterScreen: false
-	},
-	{
-		_id: SourceLayer.PgmDSK3,
-		_rank: 22,
-		name: 'DSK3 off',
-		abbreviation: '',
-		type: SourceLayerType.UNKNOWN,
-		exclusiveGroup: '',
-		isRemoteInput: false,
-		isGuestInput: false,
-		activateKeyboardHotkeys: '',
-		clearKeyboardHotkey: ',',
-		assignHotkeysToGlobalAdlibs: true,
-		isSticky: false,
-		activateStickyKeyboardHotkey: '',
-		isQueueable: false,
-		isHidden: false,
-		allowDisable: false,
-		onPresenterScreen: false
-	},
-	{
-		_id: SourceLayer.PgmDSK4,
-		_rank: 23,
-		name: 'DSK4 off',
-		abbreviation: '',
-		type: SourceLayerType.UNKNOWN,
-		exclusiveGroup: '',
-		isRemoteInput: false,
-		isGuestInput: false,
-		activateKeyboardHotkeys: '',
-		clearKeyboardHotkey: ',',
-		assignHotkeysToGlobalAdlibs: true,
-		isSticky: false,
-		activateStickyKeyboardHotkey: '',
-		isQueueable: false,
-		isHidden: false,
-		allowDisable: false,
-		onPresenterScreen: false
-	},
+	...GetDSKSourceLayerDefaults(ATEMModel.CONSTELLATION_8K_UHD_MODE),
 	{
 		_id: SourceLayer.PgmDesign,
 		_rank: 30,

--- a/src/tv2_afvd_showstyle/parts/effekt.ts
+++ b/src/tv2_afvd_showstyle/parts/effekt.ts
@@ -1,6 +1,6 @@
 import { IBlueprintPiece, SegmentContext } from '@sofie-automation/blueprints-integration'
 import { CreateEffektForPartBase, PartDefinition } from 'tv2-common'
-import { AtemLLayer, CasparLLayer, SisyfosLLAyer } from '../../tv2_afvd_studio/layers'
+import { CasparLLayer, SisyfosLLAyer } from '../../tv2_afvd_studio/layers'
 import { BlueprintConfig } from '../helpers/config'
 import { SourceLayer } from '../layers'
 
@@ -12,7 +12,6 @@ export function CreateEffektForpart(
 ) {
 	return CreateEffektForPartBase(context, config, partDefinition, pieces, {
 		sourceLayer: SourceLayer.PgmJingle,
-		atemLayer: AtemLLayer.AtemDSKEffect,
 		casparLayer: CasparLLayer.CasparPlayerJingle,
 		sisyfosLayer: SisyfosLLAyer.SisyfosSourceJingle
 	})

--- a/src/tv2_afvd_showstyle/parts/kam.ts
+++ b/src/tv2_afvd_showstyle/parts/kam.ts
@@ -17,6 +17,7 @@ import {
 	CameraParentClass,
 	CreatePartInvalid,
 	CreatePartKamBase,
+	FindDSKJingle,
 	FindSourceInfoStrict,
 	GetCameraMetaData,
 	GetLayersForCamera,
@@ -49,6 +50,8 @@ export function CreatePartKam(
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
+	const jingleDSK = FindDSKJingle(config)
+
 	if (partDefinition.rawType.match(/kam cs 3/i)) {
 		pieces.push(
 			literal<IBlueprintPiece>({
@@ -77,7 +80,7 @@ export function CreatePartKam(
 								deviceType: TSR.DeviceType.ATEM,
 								type: TSR.TimelineContentTypeAtem.ME,
 								me: {
-									input: config.studio.AtemSource.JingleFill,
+									input: jingleDSK.Fill,
 									transition: partDefinition.transition
 										? TransitionFromString(partDefinition.transition.style)
 										: TSR.AtemTransitionStyle.CUT,

--- a/src/tv2_afvd_showstyle/postProcessTimelineObjects.ts
+++ b/src/tv2_afvd_showstyle/postProcessTimelineObjects.ts
@@ -10,7 +10,7 @@ import {
 	TimelineObjHoldMode,
 	TSR
 } from '@sofie-automation/blueprints-integration'
-import { literal, TimelineBlueprintExt } from 'tv2-common'
+import { AtemLLayerDSK, FindDSKJingle, literal, TimelineBlueprintExt } from 'tv2-common'
 import * as _ from 'underscore'
 import { BlueprintConfig } from '../tv2_afvd_studio/helpers/config'
 import { AtemLLayer } from '../tv2_afvd_studio/layers'
@@ -34,6 +34,9 @@ export function postProcessPieceTimelineObjects(
 	piece: IBlueprintPieceGeneric,
 	isAdlib: boolean
 ) {
+	const jingleDSK = FindDSKJingle(config)
+	const jingleDSKLayer = AtemLLayerDSK(jingleDSK.Number)
+
 	if (piece.content?.timelineObjects) {
 		const extraObjs: TimelineObjectCoreExt[] = []
 
@@ -155,7 +158,7 @@ export function postProcessPieceTimelineObjects(
 				obj.content.type === TSR.TimelineContentTypeAtem.DSK
 		)
 		_.each(atemDskObjs, tlObj => {
-			if (tlObj.layer === AtemLLayer.AtemDSKEffect) {
+			if (tlObj.layer === jingleDSKLayer) {
 				const newProps = _.pick(tlObj.content.dsk, 'onAir')
 				if (_.isEqual(newProps, tlObj.content.dsk)) {
 					context.warning(`Unhandled Keyer properties for Clean keyer, it may look wrong`)

--- a/src/tv2_afvd_studio/__tests__/config-manifest.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/config-manifest.spec.ts
@@ -35,8 +35,7 @@ const blankStudioConfig: StudioConfig = {
 		SplitArtK: 0,
 		Default: 0,
 		MixMinusDefault: 0,
-		Continuity: 0,
-		FullFrameGrafikBackground: 0
+		Continuity: 0
 	},
 	AtemSettings: {
 		MP1Baseline: {
@@ -60,7 +59,8 @@ const blankStudioConfig: StudioConfig = {
 		KeepAliveDuration: 1000,
 		PrerollDuration: 1000,
 		OutTransitionDuration: 1000,
-		CutToMediaPlayer: 1000
+		CutToMediaPlayer: 1000,
+		FullGraphicBackground: 36
 	},
 	HTMLGraphics: {
 		GraphicURL: '',

--- a/src/tv2_afvd_studio/__tests__/config-manifest.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/config-manifest.spec.ts
@@ -1,6 +1,6 @@
 import * as _ from 'underscore'
 import { CORE_INJECTED_KEYS, studioConfigManifest } from '../config-manifests'
-import { StudioConfig } from '../helpers/config'
+import { defaultDSKConfig, StudioConfig } from '../helpers/config'
 
 const blankStudioConfig: StudioConfig = {
 	SofieHostURL: '',
@@ -30,10 +30,7 @@ const blankStudioConfig: StudioConfig = {
 	ABPlaybackDebugLogging: false,
 
 	AtemSource: {
-		DSK: [],
-		ServerC: 0,
-		JingleFill: 0,
-		JingleKey: 0,
+		DSK: defaultDSKConfig,
 		SplitArtF: 0,
 		SplitArtK: 0,
 		Default: 0,
@@ -42,10 +39,6 @@ const blankStudioConfig: StudioConfig = {
 		FullFrameGrafikBackground: 0
 	},
 	AtemSettings: {
-		CCGClip: 0,
-		CCGGain: 0,
-		VizClip: 0,
-		VizGain: 0,
 		MP1Baseline: {
 			Clip: 1,
 			Loop: false,

--- a/src/tv2_afvd_studio/__tests__/graphics.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/graphics.spec.ts
@@ -146,7 +146,7 @@ describe('Graphics', () => {
 		expect(piece.lifespan).toBe(PieceLifespan.WithinPart)
 		const content = piece.content!
 		const timeline = content.timelineObjects as TSR.TSRTimelineObj[]
-		expect(timeline).toHaveLength(19)
+		expect(timeline).toHaveLength(20)
 		const vizObj = timeline.find(
 			t =>
 				t.content.deviceType === TSR.DeviceType.VIZMSE && t.content.type === TSR.TimelineContentTypeVizMSE.ELEMENT_PILOT
@@ -324,7 +324,7 @@ describe('Graphics', () => {
 		expect(piece.lifespan).toBe(PieceLifespan.WithinPart)
 		const content = piece.content!
 		const timeline = content.timelineObjects as TSR.TSRTimelineObj[]
-		expect(timeline).toHaveLength(19)
+		expect(timeline).toHaveLength(20)
 		const vizObj = timeline.find(
 			t =>
 				t.content.deviceType === TSR.DeviceType.VIZMSE && t.content.type === TSR.TimelineContentTypeVizMSE.ELEMENT_PILOT

--- a/src/tv2_afvd_studio/__tests__/migrations-defaults.spec.ts
+++ b/src/tv2_afvd_studio/__tests__/migrations-defaults.spec.ts
@@ -1,5 +1,11 @@
-import { AbstractLLayerServerEnable } from 'tv2-common'
+import {
+	AbstractLLayerServerEnable,
+	CasparPlayerClip,
+	CasparPlayerClipLoadingLoop,
+	GetDSKMappingNames
+} from 'tv2-common'
 import * as _ from 'underscore'
+import { ATEMModel } from '../../types/atem'
 
 import { RealLLayers } from '../layers'
 import MappingsDefaults, {
@@ -28,12 +34,13 @@ describe('Migration Defaults', () => {
 		const layerIds = RealLLayers()
 			.concat(['core_abstract'])
 			.concat([
-				'casparcg_player_clip_1',
-				'casparcg_player_clip_2',
-				'casparcg_player_clip_1_loading_loop',
-				'casparcg_player_clip_2_loading_loop',
+				CasparPlayerClip(1),
+				CasparPlayerClip(2),
+				CasparPlayerClipLoadingLoop(1),
+				CasparPlayerClipLoadingLoop(2),
 				AbstractLLayerServerEnable(1),
-				AbstractLLayerServerEnable(2)
+				AbstractLLayerServerEnable(2),
+				...GetDSKMappingNames(ATEMModel.CONSTELLATION_8K_UHD_MODE)
 			])
 			.sort()
 

--- a/src/tv2_afvd_studio/__tests__/segmentContext.mock.ts
+++ b/src/tv2_afvd_studio/__tests__/segmentContext.mock.ts
@@ -58,7 +58,6 @@ const mockStudioConfig: StudioConfig = {
 		SplitArtK: 0,
 		Default: 0,
 		Continuity: 0,
-		FullFrameGrafikBackground: 0,
 		MixMinusDefault: 0
 	},
 	AtemSettings: {
@@ -83,7 +82,8 @@ const mockStudioConfig: StudioConfig = {
 		KeepAliveDuration: 1000,
 		PrerollDuration: 1000,
 		OutTransitionDuration: 1000,
-		CutToMediaPlayer: 1000
+		CutToMediaPlayer: 1000,
+		FullGraphicBackground: 36
 	},
 	HTMLGraphics: {
 		GraphicURL: '',

--- a/src/tv2_afvd_studio/__tests__/segmentContext.mock.ts
+++ b/src/tv2_afvd_studio/__tests__/segmentContext.mock.ts
@@ -8,7 +8,7 @@ import { DVEConfigInput, literal, TableConfigItemSourceMappingWithSisyfos } from
 import { SegmentContext } from '../../__mocks__/context'
 import { DefaultBreakerConfig } from '../../tv2_afvd_showstyle/__tests__/breakerConfigDefault'
 import { parseConfig as parseShowStyleConfig, ShowStyleConfig } from '../../tv2_afvd_showstyle/helpers/config'
-import { parseConfig, StudioConfig } from '../helpers/config'
+import { defaultDSKConfig, parseConfig, StudioConfig } from '../helpers/config'
 import { SisyfosLLAyer } from '../layers'
 
 const mockStudioConfig: StudioConfig = {
@@ -53,22 +53,15 @@ const mockStudioConfig: StudioConfig = {
 	ABPlaybackDebugLogging: false,
 
 	AtemSource: {
-		DSK: [],
-		ServerC: 0,
+		DSK: defaultDSKConfig,
 		SplitArtF: 0,
 		SplitArtK: 0,
 		Default: 0,
 		Continuity: 0,
-		JingleFill: 0,
-		JingleKey: 0,
 		FullFrameGrafikBackground: 0,
 		MixMinusDefault: 0
 	},
 	AtemSettings: {
-		CCGClip: 0,
-		CCGGain: 0,
-		VizClip: 0,
-		VizGain: 0,
 		MP1Baseline: {
 			Clip: 0,
 			Loop: false,

--- a/src/tv2_afvd_studio/config-manifests.ts
+++ b/src/tv2_afvd_studio/config-manifests.ts
@@ -368,14 +368,6 @@ export const studioConfigManifest: ConfigManifestEntry[] = [
 		defaultVal: 32
 	},
 	{
-		id: 'AtemSource.FullFrameGrafikBackground',
-		name: 'Full frame grafik background source',
-		description: 'ATEM source for mos full-frame grafik background source',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 36
-	},
-	{
 		id: 'AtemSource.Default',
 		name: 'ATEM Default source',
 		description: 'ATEM vision mixer default source',
@@ -537,6 +529,14 @@ export const studioConfigManifest: ConfigManifestEntry[] = [
 		type: ConfigManifestEntryType.NUMBER,
 		required: false,
 		defaultVal: 500
+	},
+	{
+		id: 'VizPilotGraphics.FullGraphicBackground',
+		name: 'Full frame grafik background source',
+		description: 'ATEM source for mos full-frame grafik background source',
+		type: ConfigManifestEntryType.NUMBER,
+		required: false,
+		defaultVal: 36
 	},
 	{
 		id: 'VizPilotGraphics.KeepAliveDuration',

--- a/src/tv2_afvd_studio/config-manifests.ts
+++ b/src/tv2_afvd_studio/config-manifests.ts
@@ -6,15 +6,15 @@ import {
 	TSR
 } from '@sofie-automation/blueprints-integration'
 import {
+	DSKConfigManifest,
 	literal,
 	MakeConfigForSources,
 	MakeConfigWithMediaFlow,
-	TableConfigItemDSK,
 	TableConfigItemSourceMapping
 } from 'tv2-common'
 import * as _ from 'underscore'
 import { AtemSourceIndex } from '../types/atem'
-import { defaultDSK } from './helpers/config'
+import { defaultDSKConfig } from './helpers/config'
 import { SisyfosLLAyer } from './layers'
 
 export const CORE_INJECTED_KEYS = ['SofieHostURL']
@@ -329,70 +329,7 @@ export const manifestAFVDStudioMics: ConfigManifestEntry = {
 	defaultVal: DEFAULT_STUDIO_MICS_LAYERS
 }
 
-export const manifestAFVDDownstreamKeyers: ConfigManifestEntryTable = {
-	id: 'AtemSource.DSK',
-	name: 'ATEM DSK',
-	description: 'ATEM Downstream Keyers Fill and Key',
-	type: ConfigManifestEntryType.TABLE,
-	required: false,
-	defaultVal: literal<Array<TableConfigItemDSK & TableConfigItemValue[0]>>([{ _id: '', ...defaultDSK }]),
-	columns: [
-		{
-			id: 'Number',
-			name: 'Number',
-			description: 'DSK number, starting from 1',
-			type: ConfigManifestEntryType.NUMBER,
-			required: true,
-			defaultVal: 1,
-			rank: 0
-		},
-		{
-			id: 'Fill',
-			name: 'ATEM Fill',
-			description: 'ATEM vision mixer input for DSK Fill',
-			type: ConfigManifestEntryType.NUMBER,
-			required: true,
-			defaultVal: 21,
-			rank: 1
-		},
-		{
-			id: 'Key',
-			name: 'ATEM Key',
-			description: 'ATEM vision mixer input for DSK Key',
-			type: ConfigManifestEntryType.NUMBER,
-			required: true,
-			defaultVal: 34,
-			rank: 2
-		},
-		{
-			id: 'Toggle',
-			name: 'AdLib Toggle',
-			description: 'Make AdLib that toggles the DSK',
-			type: ConfigManifestEntryType.BOOLEAN,
-			required: true,
-			defaultVal: false,
-			rank: 3
-		},
-		{
-			id: 'DefaultOn',
-			name: 'On by default',
-			description: 'Enable the DSK in the baseline',
-			type: ConfigManifestEntryType.BOOLEAN,
-			required: true,
-			defaultVal: false,
-			rank: 4
-		},
-		{
-			id: 'FullSource',
-			name: 'Full graphic source',
-			description: 'Use the DSK Fill as a source for Full graphics',
-			type: ConfigManifestEntryType.BOOLEAN,
-			required: true,
-			defaultVal: false,
-			rank: 5
-		}
-	]
-}
+export const manifestAFVDDownstreamKeyers: ConfigManifestEntryTable = DSKConfigManifest(defaultDSKConfig)
 
 export const studioConfigManifest: ConfigManifestEntry[] = [
 	...MakeConfigWithMediaFlow('Clip', '', 'flow0', '.mxf', '', false),
@@ -413,62 +350,6 @@ export const studioConfigManifest: ConfigManifestEntry[] = [
 		type: ConfigManifestEntryType.BOOLEAN,
 		required: false,
 		defaultVal: false
-	},
-	{
-		id: 'AtemSource.ServerC',
-		name: 'CasparCG Server C',
-		description: 'ATEM vision mixer input for ServerC',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 28
-	},
-	{
-		id: 'AtemSource.JingleFill',
-		name: 'Jingle Fill Source',
-		description: 'ATEM vision mixer input for Jingle Fill',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 29
-	},
-	{
-		id: 'AtemSource.JingleKey',
-		name: 'Jingle Key Source',
-		description: 'ATEM vision mixer input for Jingle Source',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 31
-	},
-	{
-		id: 'AtemSettings.VizClip',
-		name: 'Viz keyer clip',
-		description: 'Viz keyer clip',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 50.0
-	},
-	{
-		id: 'AtemSettings.VizGain',
-		name: 'Viz keyer gain',
-		description: 'Viz keyer gain',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 12.5
-	},
-	{
-		id: 'AtemSettings.CCGClip',
-		name: 'CasparCG keyer clip',
-		description: 'CasparCG keyer clip',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 50.0
-	},
-	{
-		id: 'AtemSettings.CCGGain',
-		name: 'CasparCG keyer gain',
-		description: 'CasparCG keyer gain',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 12.5
 	},
 	{
 		id: 'AtemSource.SplitArtF',

--- a/src/tv2_afvd_studio/helpers/config.ts
+++ b/src/tv2_afvd_studio/helpers/config.ts
@@ -35,7 +35,6 @@ export interface StudioConfig extends TV2StudioConfigBase {
 	AtemSource: {
 		SplitArtF: number // Atem MP1 Fill
 		SplitArtK: number // Atem MP1 Key
-		FullFrameGrafikBackground: number
 		DSK: TableConfigItemDSK[]
 
 		Default: number

--- a/src/tv2_afvd_studio/helpers/config.ts
+++ b/src/tv2_afvd_studio/helpers/config.ts
@@ -1,16 +1,15 @@
 import { IBlueprintConfig, IStudioContext } from '@sofie-automation/blueprints-integration'
 import {
-	DSKConfig,
 	getLiveAudioLayers,
 	getStickyLayers,
 	MediaPlayerConfig,
-	parseDSK,
 	SourceInfo,
 	TableConfigItemDSK,
 	TableConfigItemSourceMapping,
 	TableConfigItemSourceMappingWithSisyfos,
 	TV2StudioConfigBase
 } from 'tv2-common'
+import { DSKRoles } from 'tv2-constants'
 import * as _ from 'underscore'
 import { ShowStyleConfig } from '../../tv2_afvd_showstyle/helpers/config'
 import { parseMediaPlayers, parseSources } from './sources'
@@ -22,7 +21,7 @@ export interface BlueprintConfig {
 	mediaPlayers: MediaPlayerConfig // Atem Input Ids
 	liveAudio: string[]
 	stickyLayers: string[]
-	dsk: DSKConfig
+	dsk: TableConfigItemDSK[]
 }
 
 export interface StudioConfig extends TV2StudioConfigBase {
@@ -34,9 +33,6 @@ export interface StudioConfig extends TV2StudioConfigBase {
 	ABPlaybackDebugLogging: boolean
 	StudioMics: string[]
 	AtemSource: {
-		ServerC: number // Studio
-		JingleFill: number
-		JingleKey: number
 		SplitArtF: number // Atem MP1 Fill
 		SplitArtK: number // Atem MP1 Key
 		FullFrameGrafikBackground: number
@@ -48,11 +44,6 @@ export interface StudioConfig extends TV2StudioConfigBase {
 	}
 
 	AtemSettings: {
-		VizClip: number
-		VizGain: number
-		CCGClip: number
-		CCGGain: number
-
 		MP1Baseline: {
 			Clip: number
 			Loop: boolean
@@ -61,48 +52,8 @@ export interface StudioConfig extends TV2StudioConfigBase {
 	}
 }
 
-/*
-export function defaultStudioConfig(context: NotesContext): BlueprintConfig {
-	const config: BlueprintConfig = {
-		studio: {} as any,
-		showStyle: {} as any,
-		sources: [],
-		mediaPlayers: [],
-		liveAudio: [],
-		stickyLayers: []
-	}
-
-	// Load values injected by core, not via manifest
-	for (const id of CORE_INJECTED_KEYS) {
-		// Use the key as the value. Good enough for now
-		objectPath.set(config.studio, id, id)
-	}
-
-	// Load the config
-	applyToConfig(context, config.studio, studioConfigManifest, 'Studio', {})
-	// applyToConfig(context, config.showStyle, showStyleConfigManifest, 'ShowStyle', {})
-
-	config.sources = parseSources(config.studio)
-	config.mediaPlayers = parseMediaPlayers(config.studio)
-	config.liveAudio = getLiveAudioLayers(config.studio)
-	config.stickyLayers = getStickyLayers(config.studio, config.liveAudio)
-
-	return config
-}
-*/
-
-export const defaultDSK: TableConfigItemDSK = {
-	Number: 1,
-	Fill: 21,
-	Key: 34,
-	Toggle: true,
-	DefaultOn: true,
-	FullSource: true
-}
-
 export function parseConfig(rawConfig: IBlueprintConfig): any {
 	const studioConfig = (rawConfig as unknown) as StudioConfig
-	const dsk = parseDSK(studioConfig, defaultDSK)
 	const config: BlueprintConfig = {
 		studio: studioConfig,
 		showStyle: {} as any,
@@ -110,7 +61,7 @@ export function parseConfig(rawConfig: IBlueprintConfig): any {
 		mediaPlayers: [],
 		liveAudio: [],
 		stickyLayers: [],
-		dsk
+		dsk: studioConfig.AtemSource.DSK
 	}
 
 	config.sources = parseSources(studioConfig)
@@ -124,3 +75,17 @@ export function parseConfig(rawConfig: IBlueprintConfig): any {
 export function getStudioConfig(context: IStudioContext): BlueprintConfig {
 	return context.getStudioConfig() as BlueprintConfig
 }
+
+export const defaultDSKConfig: TableConfigItemDSK[] = [
+	{
+		Number: 0,
+		Key: 34,
+		Fill: 21,
+		Toggle: true,
+		DefaultOn: true,
+		Roles: [DSKRoles.FULLGFX, DSKRoles.OVERLAYGFX],
+		Clip: 50,
+		Gain: 12.5
+	},
+	{ Number: 1, Key: 31, Fill: 29, Toggle: true, DefaultOn: false, Roles: [DSKRoles.JINGLE], Clip: 50, Gain: 12.5 }
+]

--- a/src/tv2_afvd_studio/layers.ts
+++ b/src/tv2_afvd_studio/layers.ts
@@ -25,10 +25,6 @@ export enum VirtualAbstractLLayer {}
 export enum AtemLLayer {
 	AtemMEProgram = 'atem_me_program',
 	AtemMEClean = 'atem_me_clean',
-	AtemDSKGraphics = 'atem_dsk_graphics',
-	AtemDSKEffect = 'atem_dsk_effect',
-	AtemDSK3 = 'atem_dsk_3',
-	AtemDSK4 = 'atem_dsk_4',
 	AtemCleanUSKEffect = 'atem_clean_usk_effect',
 	AtemSSrcArt = 'atem_supersource_art',
 	AtemSSrcDefault = 'atem_supersource_default',
@@ -109,18 +105,3 @@ export const SisyfosLLAyer = {
 }
 
 export type SisyfosLLAyer = SharedSisyfosLLayer | AFVDSisyfosLLAyer
-
-export function CasparPlayerClip(i: number | string) {
-	return `casparcg_player_clip_${i}`
-}
-
-export function CasparPlayerClipLoadingLoop(i: number | string) {
-	return `casparcg_player_clip_${i}_loading_loop`
-}
-
-export const atemLLayersDSK: { [num: number]: string } = {
-	1: AtemLLayer.AtemDSKGraphics,
-	2: AtemLLayer.AtemDSKEffect,
-	3: AtemLLayer.AtemDSK3,
-	4: AtemLLayer.AtemDSK4
-}

--- a/src/tv2_afvd_studio/migrations/index.ts
+++ b/src/tv2_afvd_studio/migrations/index.ts
@@ -6,10 +6,11 @@ import {
 	MoveDSKToTable,
 	MoveSourcesToTable,
 	RenameStudioConfig,
+	SetConfigTo,
 	SetLayerNamesToDefaults,
 	TableConfigItemDSK
 } from 'tv2-common'
-import { GraphicLLayer } from 'tv2-constants'
+import { DSKRoles, GraphicLLayer } from 'tv2-constants'
 import * as _ from 'underscore'
 import {
 	manifestAFVDDownstreamKeyers,
@@ -161,7 +162,10 @@ export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStud
 	RenameStudioConfig('1.4.6', 'AFVD', 'MediaFlowId', 'ClipMediaFlowId'),
 	RenameStudioConfig('1.4.6', 'AFVD', 'NetworkBasePath', 'NetworkBasePathClip'),
 	RenameStudioConfig('1.4.6', 'AFVD', 'JingleBasePath', 'NetworkBasePathJingle'),
-	MoveDSKToTable('1.4.6', (manifestAFVDDownstreamKeyers.defaultVal as unknown) as TableConfigItemDSK),
+	MoveDSKToTable('1.4.6', (manifestAFVDDownstreamKeyers.defaultVal as unknown) as TableConfigItemDSK, [
+		DSKRoles.FULLGFX,
+		DSKRoles.OVERLAYGFX
+	]),
 
 	RenameStudioConfig('1.5.0', 'AFVD', 'NetworkBasePathJingle', 'JingleNetworkBasePath'),
 	RenameStudioConfig('1.5.0', 'AFVD', 'NetworkBasePathClip', 'ClipNetworkBasePath'),
@@ -176,6 +180,7 @@ export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStud
 	renameMapping('1.5.4', 'casparcg_cg_dve_template', GraphicLLayer.GraphicLLayerLocators),
 
 	...SetLayerNamesToDefaults('1.5.5', 'AFVD', MappingsDefaults),
+	SetConfigTo('1.6.1', 'AFVD', 'AtemSource.DSK', manifestAFVDDownstreamKeyers.defaultVal),
 
 	// Fill in any mappings that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations

--- a/src/tv2_afvd_studio/migrations/index.ts
+++ b/src/tv2_afvd_studio/migrations/index.ts
@@ -5,6 +5,7 @@ import {
 	MoveClipSourcePath,
 	MoveDSKToTable,
 	MoveSourcesToTable,
+	RemoveConfig,
 	RenameStudioConfig,
 	SetConfigTo,
 	SetLayerNamesToDefaults,
@@ -30,6 +31,7 @@ import {
 	GetMappingDefaultMigrationStepForLayer,
 	getMappingsDefaultsMigrationSteps,
 	GetSisyfosLayersForTableMigrationAFVD,
+	removeMapping,
 	renameMapping
 } from './util'
 
@@ -180,7 +182,21 @@ export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStud
 	renameMapping('1.5.4', 'casparcg_cg_dve_template', GraphicLLayer.GraphicLLayerLocators),
 
 	...SetLayerNamesToDefaults('1.5.5', 'AFVD', MappingsDefaults),
+
+	/**
+	 * 1.6.1
+	 * - Add concept of roles to DSK config table (and cleanup configs replaced by table)
+	 */
 	SetConfigTo('1.6.1', 'AFVD', 'AtemSource.DSK', manifestAFVDDownstreamKeyers.defaultVal),
+	RemoveConfig('1.6.1', 'AFVD', 'AtemSource.ServerC'),
+	RemoveConfig('1.6.1', 'AFVD', 'AtemSource.JingleFill'),
+	RemoveConfig('1.6.1', 'AFVD', 'AtemSource.JingleKey'),
+	RemoveConfig('1.6.1', 'AFVD', 'AtemSource.VizClip'),
+	RemoveConfig('1.6.1', 'AFVD', 'AtemSource.VizGain'),
+	RemoveConfig('1.6.1', 'AFVD', 'AtemSource.CCGClip'),
+	RemoveConfig('1.6.1', 'AFVD', 'AtemSource.CCGGain'),
+	removeMapping('1.6.1', 'atem_dsk_graphics'),
+	removeMapping('1.6.1', 'atem_dsk_efect'),
 
 	// Fill in any mappings that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations

--- a/src/tv2_afvd_studio/migrations/index.ts
+++ b/src/tv2_afvd_studio/migrations/index.ts
@@ -176,6 +176,7 @@ export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStud
 	RenameStudioConfig('1.5.0', 'AFVD', 'PilotKeepaliveDuration', 'VizPilotGraphics.KeepAliveDuration'),
 	RenameStudioConfig('1.5.0', 'AFVD', 'PilotOutTransitionDuration', 'VizPilotGraphics.OutTransitionDuration'),
 	RenameStudioConfig('1.5.0', 'AFVD', 'PilotPrerollDuration', 'VizPilotGraphics.PrerollDuration'),
+	RenameStudioConfig('1.5.0', 'AFVD', 'FullFrameGrafikBackground', 'VizPilotGraphics.FullGraphicBackground'),
 
 	renameMapping('1.5.1', 'studio0_adlib_viz_cmd', 'studio0_adlib_graphic_cmd'),
 

--- a/src/tv2_afvd_studio/migrations/mappings-defaults.ts
+++ b/src/tv2_afvd_studio/migrations/mappings-defaults.ts
@@ -1,9 +1,17 @@
 import { BlueprintMapping, BlueprintMappings, LookaheadMode, TSR } from '@sofie-automation/blueprints-integration'
-import { AbstractLLayerServerEnable, literal } from 'tv2-common'
+import {
+	AbstractLLayerServerEnable,
+	CasparPlayerClip,
+	CasparPlayerClipLoadingLoop,
+	GetDSKMappings,
+	literal,
+	SisyfosPlayerClip
+} from 'tv2-common'
 import { AbstractLLayer, GraphicLLayer } from 'tv2-constants'
 import * as _ from 'underscore'
+import { ATEMModel } from '../../types/atem'
 import { BlueprintConfig, StudioConfig } from '../helpers/config'
-import { AtemLLayer, CasparLLayer, CasparPlayerClip, CasparPlayerClipLoadingLoop, SisyfosLLAyer } from '../layers'
+import { AtemLLayer, CasparLLayer, SisyfosLLAyer } from '../layers'
 
 export const MAPPINGS_ABSTRACT: BlueprintMappings = {
 	core_abstract: literal<TSR.MappingAbstract & BlueprintMapping>({
@@ -583,34 +591,7 @@ export const MAPPINGS_ATEM: BlueprintMappings = {
 		mappingType: TSR.MappingAtemType.Auxilliary,
 		index: 11 // 11 = out 12
 	}),
-	[AtemLLayer.AtemDSKGraphics]: literal<TSR.MappingAtem & BlueprintMapping>({
-		device: TSR.DeviceType.ATEM,
-		deviceId: 'atem0',
-		lookahead: LookaheadMode.NONE,
-		mappingType: TSR.MappingAtemType.DownStreamKeyer,
-		index: 0 // 0 = DSK1
-	}),
-	[AtemLLayer.AtemDSKEffect]: literal<TSR.MappingAtem & BlueprintMapping>({
-		device: TSR.DeviceType.ATEM,
-		deviceId: 'atem0',
-		lookahead: LookaheadMode.NONE,
-		mappingType: TSR.MappingAtemType.DownStreamKeyer,
-		index: 1 // 1 = DSK2
-	}),
-	[AtemLLayer.AtemDSK3]: literal<TSR.MappingAtem & BlueprintMapping>({
-		device: TSR.DeviceType.ATEM,
-		deviceId: 'atem0',
-		lookahead: LookaheadMode.NONE,
-		mappingType: TSR.MappingAtemType.DownStreamKeyer,
-		index: 2 // 2 = DSK3
-	}),
-	[AtemLLayer.AtemDSK4]: literal<TSR.MappingAtem & BlueprintMapping>({
-		device: TSR.DeviceType.ATEM,
-		deviceId: 'atem0',
-		lookahead: LookaheadMode.NONE,
-		mappingType: TSR.MappingAtemType.DownStreamKeyer,
-		index: 3 // 3 = DSK4
-	}),
+	...GetDSKMappings(ATEMModel.CONSTELLATION_8K_UHD_MODE),
 	[AtemLLayer.AtemSSrcArt]: literal<TSR.MappingAtem & BlueprintMapping>({
 		device: TSR.DeviceType.ATEM,
 		deviceId: 'atem0',
@@ -794,14 +775,14 @@ export function getMediaPlayerMappings(mediaPlayers: BlueprintConfig['mediaPlaye
 	}
 
 	for (const mp of mediaPlayers) {
-		res[`casparcg_player_clip_${mp.id}`] = literal<TSR.MappingCasparCG & BlueprintMapping>({
+		res[CasparPlayerClip(mp.id)] = literal<TSR.MappingCasparCG & BlueprintMapping>({
 			device: TSR.DeviceType.CASPARCG,
 			deviceId: 'caspar01',
 			lookahead: LookaheadMode.NONE,
 			channel: 0, // TODO?
 			layer: 110
 		})
-		res[`sisyfos_player_clip_${mp.id}`] = literal<TSR.MappingSisyfos & BlueprintMapping>({
+		res[SisyfosPlayerClip(mp.id)] = literal<TSR.MappingSisyfos & BlueprintMapping>({
 			device: TSR.DeviceType.SISYFOS,
 			deviceId: 'sisyfos0',
 			lookahead: LookaheadMode.NONE,

--- a/src/tv2_afvd_studio/onTimelineGenerate.ts
+++ b/src/tv2_afvd_studio/onTimelineGenerate.ts
@@ -9,7 +9,7 @@ import {
 import { onTimelineGenerate } from 'tv2-common'
 import * as _ from 'underscore'
 import { getConfig } from '../tv2_afvd_showstyle/helpers/config'
-import { AtemLLayer, CasparLLayer, CasparPlayerClip, SisyfosLLAyer } from './layers'
+import { AtemLLayer, CasparLLayer, SisyfosLLAyer } from './layers'
 
 export function onTimelineGenerateAFVD(
 	context: TimelineEventContext,
@@ -27,8 +27,7 @@ export function onTimelineGenerateAFVD(
 		getConfig,
 		{
 			Caspar: {
-				ClipPending: CasparLLayer.CasparPlayerClipPending,
-				PlayerClip: CasparPlayerClip
+				ClipPending: CasparLLayer.CasparPlayerClipPending
 			},
 			Sisyfos: {
 				ClipPending: SisyfosLLAyer.SisyfosSourceClipPending,

--- a/src/tv2_offtube_showstyle/__tests__/actionExecutionContext.mock.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actionExecutionContext.mock.ts
@@ -13,7 +13,7 @@ import {
 } from '@sofie-automation/blueprints-integration'
 import { DVEConfigInput, literal, TableConfigItemSourceMappingWithSisyfos } from 'tv2-common'
 import { DefaultBreakerConfig } from '../../tv2_afvd_showstyle/__tests__/breakerConfigDefault'
-import { OfftubeStudioConfig, parseConfig } from '../../tv2_offtube_studio/helpers/config'
+import { defaultDSKConfig, OfftubeStudioConfig, parseConfig } from '../../tv2_offtube_studio/helpers/config'
 import { OfftubeSisyfosLLayer } from '../../tv2_offtube_studio/layers'
 import { OfftubeShowStyleConfig, parseConfig as parseShowStyleConfig } from '../helpers/config'
 
@@ -55,21 +55,16 @@ const mockStudioConfig: OfftubeStudioConfig = {
 	ABPlaybackDebugLogging: false,
 
 	AtemSource: {
-		DSK: [],
+		DSK: defaultDSKConfig,
 		SplitArtF: 0,
 		SplitArtK: 0,
 		Default: 0,
 		Continuity: 0,
 		SplitBackground: 0,
 		GFXFull: 0,
-		Loop: 0,
-		JingleFill: 0,
-		JingleKey: 0
+		Loop: 0
 	},
-	AtemSettings: {
-		CCGClip: 0,
-		CCGGain: 0
-	},
+	AtemSettings: {},
 	AudioBedSettings: {
 		fadeIn: 0,
 		fadeOut: 0,

--- a/src/tv2_offtube_showstyle/__tests__/actionExecutionContext.mock.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actionExecutionContext.mock.ts
@@ -80,7 +80,8 @@ const mockStudioConfig: OfftubeStudioConfig = {
 		KeepAliveDuration: 1000,
 		PrerollDuration: 1000,
 		OutTransitionDuration: 1000,
-		CutToMediaPlayer: 1000
+		CutToMediaPlayer: 1000,
+		FullGraphicBackground: 0
 	},
 	HTMLGraphics: {
 		GraphicURL: '',

--- a/src/tv2_offtube_showstyle/__tests__/actionExecutionContext.mock.ts
+++ b/src/tv2_offtube_showstyle/__tests__/actionExecutionContext.mock.ts
@@ -61,7 +61,6 @@ const mockStudioConfig: OfftubeStudioConfig = {
 		Default: 0,
 		Continuity: 0,
 		SplitBackground: 0,
-		GFXFull: 0,
 		Loop: 0
 	},
 	AtemSettings: {},

--- a/src/tv2_offtube_showstyle/__tests__/migrations-defaults.spec.ts
+++ b/src/tv2_offtube_showstyle/__tests__/migrations-defaults.spec.ts
@@ -1,4 +1,6 @@
+import { GetDSKSourceLayerNames } from 'tv2-common'
 import * as _ from 'underscore'
+import { ATEMModel } from '../../types/atem'
 
 import { OfftubeSourceLayer } from '../layers'
 import SourcelayerDefaults from '../migrations/sourcelayer-defaults'
@@ -6,7 +8,10 @@ import SourcelayerDefaults from '../migrations/sourcelayer-defaults'
 describe('Migration Defaults', () => {
 	test('SourcelayerDefaults', () => {
 		const defaultsIds = _.map(SourcelayerDefaults, v => v._id).sort()
-		const layerIds = _.values(OfftubeSourceLayer).sort()
+		const layerIds = _.values(OfftubeSourceLayer)
+			.map(l => l.toString())
+			.concat(GetDSKSourceLayerNames(ATEMModel.PRODUCTION_STUDIO_4K_2ME))
+			.sort()
 
 		expect(defaultsIds).toEqual(layerIds)
 	})

--- a/src/tv2_offtube_showstyle/actions.ts
+++ b/src/tv2_offtube_showstyle/actions.ts
@@ -57,7 +57,6 @@ export function executeActionOfftube(
 					Next: OfftubeAtemLLayer.AtemMENext,
 					ServerLookaheadAUX: OfftubeAtemLLayer.AtemAuxServerLookahead,
 					SSrcDefault: OfftubeAtemLLayer.AtemSSrcDefault,
-					Effekt: OfftubeAtemLLayer.AtemDSKGraphics,
 					cutOnclean: true
 				}
 			},

--- a/src/tv2_offtube_showstyle/cues/OfftubeGraphics.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeGraphics.ts
@@ -10,6 +10,7 @@ import {
 	CreateInternalGraphic,
 	CreatePilotGraphic,
 	CueDefinitionGraphic,
+	FindDSKFullGFX,
 	GetSisyfosTimelineObjForCamera,
 	GraphicInternalOrPilot,
 	GraphicIsInternal,
@@ -62,6 +63,7 @@ export function OfftubeEvaluateGrafikCaspar(
 }
 
 function createPilotTimeline(config: OfftubeShowstyleBlueprintConfig, context: NotesContext): TSR.TSRTimelineObj[] {
+	const fullDSK = FindDSKFullGFX(config)
 	return [
 		literal<TSR.TimelineObjAtemME>({
 			id: '',
@@ -74,7 +76,7 @@ function createPilotTimeline(config: OfftubeShowstyleBlueprintConfig, context: N
 				deviceType: TSR.DeviceType.ATEM,
 				type: TSR.TimelineContentTypeAtem.ME,
 				me: {
-					input: config.studio.AtemSource.GFXFull,
+					input: fullDSK.Fill,
 					transition: TSR.AtemTransitionStyle.WIPE,
 					transitionSettings: {
 						wipe: {

--- a/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
@@ -135,7 +135,6 @@ export function createJingleContentOfftube(
 				PlayerJingleLookahead: OfftubeCasparLLayer.CasparPlayerJingleLookahead
 			},
 			ATEM: {
-				DSKJingle: OfftubeAtemLLayer.AtemDSKGraphics,
 				USKJinglePreview: OfftubeAtemLLayer.AtemMENextJingle
 			},
 			Sisyfos: {

--- a/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
+++ b/src/tv2_offtube_showstyle/cues/OfftubeJingle.ts
@@ -122,25 +122,16 @@ export function createJingleContentOfftube(
 	duration: number,
 	alphaAtEnd: number
 ) {
-	return CreateJingleContentBase(
-		config,
-		file,
-		alphaAtStart,
-		loadFirstFrame,
-		duration,
-		alphaAtEnd,
-		{
-			Caspar: {
-				PlayerJingle: OfftubeCasparLLayer.CasparPlayerJingle,
-				PlayerJingleLookahead: OfftubeCasparLLayer.CasparPlayerJingleLookahead
-			},
-			ATEM: {
-				USKJinglePreview: OfftubeAtemLLayer.AtemMENextJingle
-			},
-			Sisyfos: {
-				PlayerJingle: OfftubeSisyfosLLayer.SisyfosSourceJingle
-			}
+	return CreateJingleContentBase(config, file, alphaAtStart, loadFirstFrame, duration, alphaAtEnd, {
+		Caspar: {
+			PlayerJingle: OfftubeCasparLLayer.CasparPlayerJingle,
+			PlayerJingleLookahead: OfftubeCasparLLayer.CasparPlayerJingleLookahead
 		},
-		false
-	)
+		ATEM: {
+			USKJinglePreview: OfftubeAtemLLayer.AtemMENextJingle
+		},
+		Sisyfos: {
+			PlayerJingle: OfftubeSisyfosLLayer.SisyfosSourceJingle
+		}
+	})
 }

--- a/src/tv2_offtube_showstyle/migrations/index.ts
+++ b/src/tv2_offtube_showstyle/migrations/index.ts
@@ -124,6 +124,12 @@ export const showStyleMigrations: MigrationStepShowStyle[] = literal<MigrationSt
 		IsDesign: false
 	}),
 
+	/**
+	 * 1.6.1
+	 * - Remove studio0_dsk_cmd, will be replaced by studio0_dsk_1_cmd by defaults
+	 */
+	removeSourceLayer('1.6.1', 'AFVD', 'studio0_dsk_cmd'),
+
 	...getSourceLayerDefaultsMigrationSteps(VERSION),
 	...getOutputLayerDefaultsMigrationSteps(VERSION)
 ])

--- a/src/tv2_offtube_showstyle/migrations/sourcelayer-defaults.ts
+++ b/src/tv2_offtube_showstyle/migrations/sourcelayer-defaults.ts
@@ -1,6 +1,7 @@
 import { ISourceLayer, SourceLayerType } from '@sofie-automation/blueprints-integration'
-import { literal } from 'tv2-common'
+import { GetDSKSourceLayerDefaults, literal } from 'tv2-common'
 import { SharedSourceLayers } from 'tv2-constants'
+import { ATEMModel } from '../../types/atem'
 import { OfftubeSourceLayer } from '../layers'
 
 // OVERLAY group
@@ -471,82 +472,7 @@ const PGM: ISourceLayer[] = [
 		allowDisable: false,
 		onPresenterScreen: false
 	},
-	{
-		_id: OfftubeSourceLayer.PgmDSK1,
-		_rank: 20,
-		name: 'DSK1 off',
-		abbreviation: '',
-		type: SourceLayerType.UNKNOWN,
-		exclusiveGroup: '',
-		isRemoteInput: false,
-		isGuestInput: false,
-		activateKeyboardHotkeys: '',
-		clearKeyboardHotkey: ',',
-		assignHotkeysToGlobalAdlibs: true,
-		isSticky: false,
-		activateStickyKeyboardHotkey: '',
-		isQueueable: false,
-		isHidden: false,
-		allowDisable: false,
-		onPresenterScreen: false
-	},
-	{
-		_id: OfftubeSourceLayer.PgmDSK2,
-		_rank: 21,
-		name: 'DSK2 off',
-		abbreviation: '',
-		type: SourceLayerType.UNKNOWN,
-		exclusiveGroup: '',
-		isRemoteInput: false,
-		isGuestInput: false,
-		activateKeyboardHotkeys: '',
-		clearKeyboardHotkey: ',',
-		assignHotkeysToGlobalAdlibs: true,
-		isSticky: false,
-		activateStickyKeyboardHotkey: '',
-		isQueueable: false,
-		isHidden: false,
-		allowDisable: false,
-		onPresenterScreen: false
-	},
-	{
-		_id: OfftubeSourceLayer.PgmDSK3,
-		_rank: 22,
-		name: 'DSK3 off',
-		abbreviation: '',
-		type: SourceLayerType.UNKNOWN,
-		exclusiveGroup: '',
-		isRemoteInput: false,
-		isGuestInput: false,
-		activateKeyboardHotkeys: '',
-		clearKeyboardHotkey: ',',
-		assignHotkeysToGlobalAdlibs: true,
-		isSticky: false,
-		activateStickyKeyboardHotkey: '',
-		isQueueable: false,
-		isHidden: false,
-		allowDisable: false,
-		onPresenterScreen: false
-	},
-	{
-		_id: OfftubeSourceLayer.PgmDSK4,
-		_rank: 23,
-		name: 'DSK4 off',
-		abbreviation: '',
-		type: SourceLayerType.UNKNOWN,
-		exclusiveGroup: '',
-		isRemoteInput: false,
-		isGuestInput: false,
-		activateKeyboardHotkeys: '',
-		clearKeyboardHotkey: ',',
-		assignHotkeysToGlobalAdlibs: true,
-		isSticky: false,
-		activateStickyKeyboardHotkey: '',
-		isQueueable: false,
-		isHidden: false,
-		allowDisable: false,
-		onPresenterScreen: false
-	}
+	...GetDSKSourceLayerDefaults(ATEMModel.PRODUCTION_STUDIO_4K_2ME)
 ]
 
 // MUSIK group

--- a/src/tv2_offtube_showstyle/onTimelineGenerate.ts
+++ b/src/tv2_offtube_showstyle/onTimelineGenerate.ts
@@ -9,12 +9,7 @@ import {
 } from '@sofie-automation/blueprints-integration'
 import { disablePilotWipeAfterJingle, onTimelineGenerate, PartEndStateExt, TimelineBlueprintExt } from 'tv2-common'
 import { GraphicLLayer, TallyTags } from 'tv2-constants'
-import {
-	CasparPlayerClip,
-	OfftubeAtemLLayer,
-	OfftubeCasparLLayer,
-	OfftubeSisyfosLLayer
-} from '../tv2_offtube_studio/layers'
+import { OfftubeAtemLLayer, OfftubeCasparLLayer, OfftubeSisyfosLLayer } from '../tv2_offtube_studio/layers'
 import { getConfig } from './helpers/config'
 
 export function onTimelineGenerateOfftube(
@@ -24,39 +19,6 @@ export function onTimelineGenerateOfftube(
 	previousPartEndState: PartEndState | undefined,
 	resolvedPieces: IBlueprintResolvedPieceInstance[]
 ): Promise<BlueprintResultTimeline> {
-	// If we are not in a server, then disable the server adlib piece
-	/*const currentPartId = context.part._id
-	const currentPieces: { [id: string]: IBlueprintResolvedPieceInstance } = {}
-	for (const piece of resolvedPieces) {
-		if (piece.piece.partId === currentPartId) {
-			currentPieces[piece._id] = piece
-		}
-	}
-	const currentServerOnAir = Object.values(currentPieces).find(
-		p => p.piece.sourceLayerId === OfftubeSourceLayer.PgmServer
-	)
-	if (!currentServerOnAir) {
-		const currentAdlibServerPieceGroup = timeline.find(
-			obj =>
-				obj.isGroup &&
-				(obj.layer === OfftubeSourceLayer.SelectedAdLibServer ||
-					obj.layer === OfftubeSourceLayer.SelectedAdLibVoiceOver) &&
-				obj.pieceInstanceId &&
-				currentPieces[obj.pieceInstanceId]
-		)
-		if (currentAdlibServerPieceGroup) {
-			const enableObj = timeline.find(
-				obj =>
-					(obj as any).inGroup === currentAdlibServerPieceGroup.id &&
-					obj.layer === OfftubeAbstractLLayer.OfftubeAbstractLLayerServerEnable
-			)
-			if (enableObj) {
-				// This is the master object that looks for the class coming from OfftubeSourceLayer.PgmServer to say it is on air. We know that doesnt exist here, so ignore it
-				enableObj.enable = { while: '0' }
-			}
-		}
-	}*/
-
 	const previousPartEndState2 = previousPartEndState as PartEndStateExt | undefined
 	disablePilotWipeAfterJingle(timeline, previousPartEndState2, resolvedPieces)
 	disableFirstPilotGFXAnimation(context, timeline, previousPartEndState2, resolvedPieces)
@@ -70,8 +32,7 @@ export function onTimelineGenerateOfftube(
 		getConfig,
 		{
 			Caspar: {
-				ClipPending: OfftubeCasparLLayer.CasparPlayerClipPending,
-				PlayerClip: CasparPlayerClip
+				ClipPending: OfftubeCasparLLayer.CasparPlayerClipPending
 			},
 			Sisyfos: {
 				ClipPending: OfftubeSisyfosLLayer.SisyfosSourceClipPending,

--- a/src/tv2_offtube_showstyle/parts/OfftubeEffekt.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeEffekt.ts
@@ -1,7 +1,7 @@
 import { IBlueprintPiece, NotesContext } from '@sofie-automation/blueprints-integration'
 import { CreateEffektForPartBase, PartDefinition } from 'tv2-common'
 import { SharedSourceLayers } from 'tv2-constants'
-import { OfftubeAtemLLayer, OfftubeCasparLLayer, OfftubeSisyfosLLayer } from '../../tv2_offtube_studio/layers'
+import { OfftubeCasparLLayer, OfftubeSisyfosLLayer } from '../../tv2_offtube_studio/layers'
 import { OfftubeShowstyleBlueprintConfig } from '../helpers/config'
 
 export function CreateEffektForpart(
@@ -12,7 +12,6 @@ export function CreateEffektForpart(
 ) {
 	return CreateEffektForPartBase(context, config, partDefinition, pieces, {
 		sourceLayer: SharedSourceLayers.PgmJingle,
-		atemLayer: OfftubeAtemLLayer.AtemDSKGraphics,
 		casparLayer: OfftubeCasparLLayer.CasparPlayerJingle,
 		sisyfosLayer: OfftubeSisyfosLLayer.SisyfosSourceJingle
 	})

--- a/src/tv2_offtube_showstyle/parts/OfftubeKam.ts
+++ b/src/tv2_offtube_showstyle/parts/OfftubeKam.ts
@@ -17,6 +17,7 @@ import {
 	CameraParentClass,
 	CreatePartInvalid,
 	CreatePartKamBase,
+	FindDSKJingle,
 	FindSourceInfoStrict,
 	GetCameraMetaData,
 	GetLayersForCamera,
@@ -50,6 +51,8 @@ export function OfftubeCreatePartKam(
 	const actions: IBlueprintActionManifest[] = []
 	const mediaSubscriptions: HackPartMediaObjectSubscription[] = []
 
+	const jingleDSK = FindDSKJingle(config)
+
 	if (partDefinition.rawType.match(/kam cs 3/i)) {
 		pieces.push(
 			literal<IBlueprintPiece>({
@@ -62,7 +65,7 @@ export function OfftubeCreatePartKam(
 				tags: [GetTagForKam('JINGLE'), TallyTags.JINGLE_IS_LIVE],
 				content: literal<VTContent>({
 					studioLabel: '',
-					switcherInput: config.dsk[1].Fill,
+					switcherInput: jingleDSK.Fill,
 					ignoreMediaObjectStatus: true,
 					fileName: '',
 					path: '',
@@ -80,7 +83,7 @@ export function OfftubeCreatePartKam(
 								deviceType: TSR.DeviceType.ATEM,
 								type: TSR.TimelineContentTypeAtem.ME,
 								me: {
-									input: config.dsk[1].Fill,
+									input: jingleDSK.Fill,
 									transition: partDefinition.transition
 										? TransitionFromString(partDefinition.transition.style)
 										: TSR.AtemTransitionStyle.CUT,

--- a/src/tv2_offtube_studio/__tests__/config-manifest.spec.ts
+++ b/src/tv2_offtube_studio/__tests__/config-manifest.spec.ts
@@ -1,6 +1,6 @@
 import * as _ from 'underscore'
 import { CORE_INJECTED_KEYS, studioConfigManifest } from '../config-manifests'
-import { OfftubeStudioConfig } from '../helpers/config'
+import { defaultDSKConfig, OfftubeStudioConfig } from '../helpers/config'
 
 const blankStudioConfig: OfftubeStudioConfig = {
 	SofieHostURL: '',
@@ -24,21 +24,16 @@ const blankStudioConfig: OfftubeStudioConfig = {
 	ABPlaybackDebugLogging: false,
 
 	AtemSource: {
-		DSK: [],
+		DSK: defaultDSKConfig,
 		SplitArtF: 0,
 		SplitArtK: 0,
 		Default: 0,
 		Continuity: 0,
 		SplitBackground: 0,
 		GFXFull: 0,
-		Loop: 0,
-		JingleFill: 0,
-		JingleKey: 0
+		Loop: 0
 	},
-	AtemSettings: {
-		CCGClip: 0,
-		CCGGain: 0
-	},
+	AtemSettings: {},
 	AudioBedSettings: {
 		fadeIn: 0,
 		fadeOut: 0,

--- a/src/tv2_offtube_studio/__tests__/config-manifest.spec.ts
+++ b/src/tv2_offtube_studio/__tests__/config-manifest.spec.ts
@@ -30,7 +30,6 @@ const blankStudioConfig: OfftubeStudioConfig = {
 		Default: 0,
 		Continuity: 0,
 		SplitBackground: 0,
-		GFXFull: 0,
 		Loop: 0
 	},
 	AtemSettings: {},

--- a/src/tv2_offtube_studio/__tests__/config-manifest.spec.ts
+++ b/src/tv2_offtube_studio/__tests__/config-manifest.spec.ts
@@ -55,7 +55,8 @@ const blankStudioConfig: OfftubeStudioConfig = {
 		KeepAliveDuration: 1000,
 		PrerollDuration: 1000,
 		OutTransitionDuration: 1000,
-		CutToMediaPlayer: 1000
+		CutToMediaPlayer: 1000,
+		FullGraphicBackground: 0
 	},
 	HTMLGraphics: {
 		GraphicURL: '',

--- a/src/tv2_offtube_studio/__tests__/migrations-defaults.spec.ts
+++ b/src/tv2_offtube_studio/__tests__/migrations-defaults.spec.ts
@@ -1,5 +1,11 @@
-import { AbstractLLayerServerEnable } from 'tv2-common'
+import {
+	AbstractLLayerServerEnable,
+	CasparPlayerClip,
+	CasparPlayerClipLoadingLoop,
+	GetDSKMappingNames
+} from 'tv2-common'
 import * as _ from 'underscore'
+import { ATEMModel } from '../../types/atem'
 
 import { RealLLayers } from '../layers'
 import MappingsDefaults from '../migrations/mappings-defaults'
@@ -19,12 +25,13 @@ describe('Migration Defaults', () => {
 		const layerIds = RealLLayers()
 			.concat(['core_abstract'])
 			.concat([
-				'casparcg_player_clip_1',
-				'casparcg_player_clip_2',
-				'casparcg_player_clip_1_loading_loop',
-				'casparcg_player_clip_2_loading_loop',
+				CasparPlayerClip(1),
+				CasparPlayerClip(2),
+				CasparPlayerClipLoadingLoop(1),
+				CasparPlayerClipLoadingLoop(2),
 				AbstractLLayerServerEnable(1),
-				AbstractLLayerServerEnable(2)
+				AbstractLLayerServerEnable(2),
+				...GetDSKMappingNames(ATEMModel.PRODUCTION_STUDIO_4K_2ME)
 			])
 			.sort()
 

--- a/src/tv2_offtube_studio/config-manifests.ts
+++ b/src/tv2_offtube_studio/config-manifests.ts
@@ -6,15 +6,15 @@ import {
 	TSR
 } from '@sofie-automation/blueprints-integration'
 import {
+	DSKConfigManifest,
 	literal,
 	MakeConfigForSources,
 	MakeConfigWithMediaFlow,
-	TableConfigItemDSK,
 	TableConfigItemSourceMapping
 } from 'tv2-common'
 import * as _ from 'underscore'
 import { AtemSourceIndex } from '../types/atem'
-import { defaultDSK } from './helpers/config'
+import { defaultDSKConfig } from './helpers/config'
 import { OfftubeSisyfosLLayer } from './layers'
 
 export const CORE_INJECTED_KEYS = ['SofieHostURL']
@@ -120,70 +120,7 @@ export const manifestOfftubeStudioMics: ConfigManifestEntry = {
 	defaultVal: DEFAULT_STUDIO_MICS_LAYERS
 }
 
-export const manifestOfftubeDownstreamKeyers: ConfigManifestEntryTable = {
-	id: 'AtemSource.DSK',
-	name: 'ATEM DSK',
-	description: 'ATEM Downstream Keyers Fill and Key',
-	type: ConfigManifestEntryType.TABLE,
-	required: false,
-	defaultVal: literal<Array<TableConfigItemDSK & TableConfigItemValue[0]>>([{ _id: '', ...defaultDSK }]),
-	columns: [
-		{
-			id: 'Number',
-			name: 'Number',
-			description: 'DSK number, starting from 1',
-			type: ConfigManifestEntryType.NUMBER,
-			required: true,
-			defaultVal: 1,
-			rank: 0
-		},
-		{
-			id: 'Fill',
-			name: 'ATEM Fill',
-			description: 'ATEM vision mixer input for DSK Fill',
-			type: ConfigManifestEntryType.NUMBER,
-			required: true,
-			defaultVal: 21,
-			rank: 1
-		},
-		{
-			id: 'Key',
-			name: 'ATEM Key',
-			description: 'ATEM vision mixer input for DSK Key',
-			type: ConfigManifestEntryType.NUMBER,
-			required: true,
-			defaultVal: 34,
-			rank: 2
-		},
-		{
-			id: 'Toggle',
-			name: 'AdLib Toggle',
-			description: 'Make AdLib that toggles the DSK',
-			type: ConfigManifestEntryType.BOOLEAN,
-			required: true,
-			defaultVal: false,
-			rank: 3
-		},
-		{
-			id: 'DefaultOn',
-			name: 'On by default',
-			description: 'Enable the DSK in the baseline',
-			type: ConfigManifestEntryType.BOOLEAN,
-			required: true,
-			defaultVal: false,
-			rank: 4
-		},
-		{
-			id: 'FullSource',
-			name: 'Full graphic source',
-			description: 'Use the DSK Fill as a source for Full graphics',
-			type: ConfigManifestEntryType.BOOLEAN,
-			required: true,
-			defaultVal: false,
-			rank: 5
-		}
-	]
-}
+export const manifestOfftubeDownstreamKeyers: ConfigManifestEntryTable = DSKConfigManifest(defaultDSKConfig)
 
 export const studioConfigManifest: ConfigManifestEntry[] = [
 	...MakeConfigWithMediaFlow('Clip', '', 'flow0', '.mxf', '', false),
@@ -203,38 +140,6 @@ export const studioConfigManifest: ConfigManifestEntry[] = [
 		type: ConfigManifestEntryType.BOOLEAN,
 		required: false,
 		defaultVal: false
-	},
-	{
-		id: 'AtemSource.JingleFill',
-		name: 'Jingle Fill Source',
-		description: 'ATEM vision mixer input for Jingle Fill',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 7
-	},
-	{
-		id: 'AtemSource.JingleKey',
-		name: 'Jingle Key Source',
-		description: 'ATEM vision mixer input for Jingle Source',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 8
-	},
-	{
-		id: 'AtemSettings.CCGClip',
-		name: 'CasparCG keyer clip',
-		description: 'CasparCG keyer clip',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 50.0
-	},
-	{
-		id: 'AtemSettings.CCGGain',
-		name: 'CasparCG keyer gain',
-		description: 'CasparCG keyer gain',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 12.5
 	},
 	{
 		id: 'AtemSource.SplitArtF',

--- a/src/tv2_offtube_studio/config-manifests.ts
+++ b/src/tv2_offtube_studio/config-manifests.ts
@@ -166,14 +166,6 @@ export const studioConfigManifest: ConfigManifestEntry[] = [
 		defaultVal: 11
 	},
 	{
-		id: 'AtemSource.GFXFull',
-		name: 'Full graphics source',
-		description: 'ATEM source for full graphics',
-		type: ConfigManifestEntryType.NUMBER,
-		required: false,
-		defaultVal: 12
-	},
-	{
 		id: 'AtemSource.Loop',
 		name: 'Studio screen loop graphics source',
 		description: 'ATEM source for loop for studio screen',

--- a/src/tv2_offtube_studio/config-manifests.ts
+++ b/src/tv2_offtube_studio/config-manifests.ts
@@ -349,6 +349,14 @@ export const studioConfigManifest: ConfigManifestEntry[] = [
 		defaultVal: 2000
 	},
 	{
+		id: 'VizPilotGraphics.FullGraphicBackground',
+		name: 'Full frame grafik background source',
+		description: 'ATEM source for mos full-frame grafik background source',
+		type: ConfigManifestEntryType.NUMBER,
+		required: false,
+		defaultVal: 0
+	},
+	{
 		id: 'PreventOverlayWithFull',
 		name: 'Prevent Overlay with Full',
 		description: 'Stop overlay elements from showing when a Full graphic is on-air',

--- a/src/tv2_offtube_studio/helpers/config.ts
+++ b/src/tv2_offtube_studio/helpers/config.ts
@@ -1,15 +1,14 @@
 import { IBlueprintConfig } from '@sofie-automation/blueprints-integration'
 import {
-	DSKConfig,
 	getLiveAudioLayers,
 	getStickyLayers,
 	MediaPlayerConfig,
-	parseDSK,
 	SourceInfo,
 	TableConfigItemDSK,
 	TableConfigItemSourceMapping,
 	TV2StudioConfigBase
 } from 'tv2-common'
+import { DSKRoles } from 'tv2-constants'
 import * as _ from 'underscore'
 import { parseMediaPlayers, parseSources } from './sources'
 
@@ -19,7 +18,7 @@ export interface OfftubeStudioBlueprintConfig {
 	mediaPlayers: MediaPlayerConfig // Atem Input Ids
 	liveAudio: string[]
 	stickyLayers: string[]
-	dsk: DSKConfig
+	dsk: TableConfigItemDSK[]
 }
 
 export interface OfftubeStudioConfig extends TV2StudioConfigBase {
@@ -38,14 +37,9 @@ export interface OfftubeStudioConfig extends TV2StudioConfigBase {
 
 		Default: number
 		Continuity: number
-		JingleFill: number
-		JingleKey: number
 	}
 
-	AtemSettings: {
-		CCGClip: number
-		CCGGain: number
-	}
+	AtemSettings: {}
 
 	AudioBedSettings: {
 		fadeIn: number
@@ -58,18 +52,8 @@ export interface OfftubeStudioConfig extends TV2StudioConfigBase {
 	IdleSisyfosLayers: string[]
 }
 
-export const defaultDSK: TableConfigItemDSK = {
-	Number: 1,
-	Fill: 7,
-	Key: 8,
-	Toggle: true,
-	DefaultOn: true,
-	FullSource: true
-}
-
 export function parseConfig(rawConfig: IBlueprintConfig): OfftubeStudioBlueprintConfig {
 	const studioConfig = (rawConfig as unknown) as OfftubeStudioConfig
-	const dsk = parseDSK(studioConfig, defaultDSK)
 	const config: OfftubeStudioBlueprintConfig = {
 		studio: rawConfig as any,
 		// showStyle: {} as any,
@@ -77,7 +61,7 @@ export function parseConfig(rawConfig: IBlueprintConfig): OfftubeStudioBlueprint
 		mediaPlayers: [],
 		liveAudio: [],
 		stickyLayers: [],
-		dsk
+		dsk: studioConfig.AtemSource.DSK
 	}
 	config.sources = parseSources(studioConfig)
 	config.mediaPlayers = parseMediaPlayers(studioConfig)
@@ -86,3 +70,16 @@ export function parseConfig(rawConfig: IBlueprintConfig): OfftubeStudioBlueprint
 
 	return config
 }
+
+export const defaultDSKConfig: TableConfigItemDSK[] = [
+	{
+		Number: 0,
+		Key: 8,
+		Fill: 7,
+		Toggle: true,
+		DefaultOn: true,
+		Roles: [DSKRoles.JINGLE, DSKRoles.OVERLAYGFX],
+		Clip: 50.0,
+		Gain: 12.5
+	}
+]

--- a/src/tv2_offtube_studio/helpers/config.ts
+++ b/src/tv2_offtube_studio/helpers/config.ts
@@ -87,7 +87,7 @@ export const defaultDSKConfig: TableConfigItemDSK[] = [
 		Key: 0,
 		Fill: 12,
 		Toggle: true,
-		DefaultOn: true,
+		DefaultOn: false,
 		Roles: [DSKRoles.FULLGFX],
 		Clip: 50.0,
 		Gain: 12.5

--- a/src/tv2_offtube_studio/helpers/config.ts
+++ b/src/tv2_offtube_studio/helpers/config.ts
@@ -31,7 +31,6 @@ export interface OfftubeStudioConfig extends TV2StudioConfigBase {
 		SplitArtF: number // Atem MP1 Fill
 		SplitArtK: number // Atem MP1 Key
 		SplitBackground: number
-		GFXFull: number
 		Loop: number
 		DSK: TableConfigItemDSK[]
 
@@ -79,6 +78,17 @@ export const defaultDSKConfig: TableConfigItemDSK[] = [
 		Toggle: true,
 		DefaultOn: true,
 		Roles: [DSKRoles.JINGLE, DSKRoles.OVERLAYGFX],
+		Clip: 50.0,
+		Gain: 12.5
+	},
+	// Offtube doesn't use DSK for fulls, but this prevents duplicate studio configs + easy switchover to Viz engine
+	{
+		Number: 0,
+		Key: 0,
+		Fill: 12,
+		Toggle: true,
+		DefaultOn: true,
+		Roles: [DSKRoles.FULLGFX],
 		Clip: 50.0,
 		Gain: 12.5
 	}

--- a/src/tv2_offtube_studio/helpers/config.ts
+++ b/src/tv2_offtube_studio/helpers/config.ts
@@ -83,10 +83,10 @@ export const defaultDSKConfig: TableConfigItemDSK[] = [
 	},
 	// Offtube doesn't use DSK for fulls, but this prevents duplicate studio configs + easy switchover to Viz engine
 	{
-		Number: 0,
+		Number: 1,
 		Key: 0,
 		Fill: 12,
-		Toggle: true,
+		Toggle: false,
 		DefaultOn: false,
 		Roles: [DSKRoles.FULLGFX],
 		Clip: 50.0,

--- a/src/tv2_offtube_studio/layers.ts
+++ b/src/tv2_offtube_studio/layers.ts
@@ -45,10 +45,6 @@ enum SisyfosLLayer {
 
 export enum OfftubeAtemLLayer {
 	AtemMEClean = 'atem_me_clean',
-	AtemDSKGraphics = 'atem_dsk_graphics',
-	AtemDSK2 = 'atem_dsk_2',
-	AtemDSK3 = 'atem_dsk_3',
-	AtemDSK4 = 'atem_dsk_4',
 	AtemMEProgram = 'atem_me_program',
 	AtemMENext = 'atem_me_next',
 	AtemMENextJingle = 'atem_me_next_jingle',
@@ -87,18 +83,3 @@ export const OfftubeSisyfosLLayer = {
 }
 
 export type OfftubeSisyfosLLayer = SharedSisyfosLLayer | SisyfosLLayer
-
-export function CasparPlayerClip(i: number | string) {
-	return `casparcg_player_clip_${i}`
-}
-
-export function CasparPlayerClipLoadingLoop(i: number | string) {
-	return `casparcg_player_clip_${i}_loading_loop`
-}
-
-export const atemLLayersDSK: { [num: number]: string } = {
-	1: OfftubeAtemLLayer.AtemDSKGraphics,
-	2: OfftubeAtemLLayer.AtemDSK2,
-	3: OfftubeAtemLLayer.AtemDSK3,
-	4: OfftubeAtemLLayer.AtemDSK4
-}

--- a/src/tv2_offtube_studio/migrations/index.ts
+++ b/src/tv2_offtube_studio/migrations/index.ts
@@ -10,6 +10,7 @@ import {
 	MoveClipSourcePath,
 	MoveDSKToTable,
 	MoveSourcesToTable,
+	RemoveConfig,
 	RenameStudioConfig,
 	SetConfigTo,
 	SetLayerNamesToDefaults,
@@ -310,8 +311,18 @@ export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStud
 
 	GetMappingDefaultMigrationStepForLayer('1.6.0', GraphicLLayer.GraphicLLayerPilot, true),
 
+	/**
+	 * 1.6.1
+	 * - Split RM config into FEED and RM configs
+	 * - Add concept of roles to DSK config table (and cleanup configs replaced by table)
+	 */
 	SetConfigTo('1.6.1', 'Offtube', 'SourcesRM', manifestOfftubeSourcesRM.defaultVal),
 	SetConfigTo('1.6.1', 'Offtube', 'AtemSource.DSK', manifestOfftubeDownstreamKeyers.defaultVal),
+	RemoveConfig('1.6.1', 'Offtube', 'AtemSource.JingleFill'),
+	RemoveConfig('1.6.1', 'Offtube', 'AtemSource.JingleKey'),
+	RemoveConfig('1.6.1', 'Offtube', 'AtemSource.CCGClip'),
+	RemoveConfig('1.6.1', 'Offtube', 'AtemSource.CCGGain'),
+	removeMapping('1.6.1', 'atem_dsk_graphics'),
 
 	// Fill in any mappings that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations

--- a/src/tv2_offtube_studio/migrations/index.ts
+++ b/src/tv2_offtube_studio/migrations/index.ts
@@ -11,10 +11,11 @@ import {
 	MoveDSKToTable,
 	MoveSourcesToTable,
 	RenameStudioConfig,
+	SetConfigTo,
 	SetLayerNamesToDefaults,
 	TableConfigItemDSK
 } from 'tv2-common'
-import { GraphicLLayer } from 'tv2-constants'
+import { DSKRoles, GraphicLLayer } from 'tv2-constants'
 import * as _ from 'underscore'
 import { EnsureSisyfosMappingHasType } from '../../tv2_afvd_studio/migrations/util'
 import {
@@ -33,8 +34,7 @@ import {
 	getMappingsDefaultsMigrationSteps,
 	GetSisyfosLayersForTableMigrationOfftube,
 	removeMapping,
-	renameMapping,
-	setConfigTo
+	renameMapping
 } from './util'
 
 declare const VERSION: string // Injected by webpack
@@ -269,7 +269,10 @@ export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStud
 	RenameStudioConfig('1.4.6', 'Offtube', 'GraphicBasePath', 'NetworkBasePathGraphic'),
 	RenameStudioConfig('1.4.6', 'Offtube', 'GraphicFlowId', 'GraphicMediaFlowId'),
 
-	MoveDSKToTable('1.4.6', (manifestOfftubeDownstreamKeyers.defaultVal as unknown) as TableConfigItemDSK),
+	MoveDSKToTable('1.4.6', (manifestOfftubeDownstreamKeyers.defaultVal as unknown) as TableConfigItemDSK, [
+		DSKRoles.JINGLE,
+		DSKRoles.OVERLAYGFX
+	]),
 
 	GetMappingDefaultMigrationStepForLayer('1.4.8', OfftubeCasparLLayer.CasparPlayerJingleLookahead, true),
 
@@ -299,7 +302,7 @@ export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStud
 	GetMappingDefaultMigrationStepForLayer('1.5.3', GraphicLLayer.GraphicLLayerPilot, true),
 	GetMappingDefaultMigrationStepForLayer('1.5.3', GraphicLLayer.GraphicLLayerPilotOverlay, true),
 	GetMappingDefaultMigrationStepForLayer('1.5.3', GraphicLLayer.GraphicLLayerFullLoop, true),
-	setConfigTo('1.5.3', 'AtemSource.GFXFull', 12),
+	SetConfigTo('1.5.3', 'Offtube', 'AtemSource.GFXFull', 12),
 
 	renameMapping('1.5.4', 'casparcg_cg_dve_template', GraphicLLayer.GraphicLLayerLocators),
 
@@ -307,7 +310,8 @@ export const studioMigrations: MigrationStepStudio[] = literal<MigrationStepStud
 
 	GetMappingDefaultMigrationStepForLayer('1.6.0', GraphicLLayer.GraphicLLayerPilot, true),
 
-	setConfigTo('1.6.1', 'SourcesRM', manifestOfftubeSourcesRM.defaultVal),
+	SetConfigTo('1.6.1', 'Offtube', 'SourcesRM', manifestOfftubeSourcesRM.defaultVal),
+	SetConfigTo('1.6.1', 'Offtube', 'AtemSource.DSK', manifestOfftubeDownstreamKeyers.defaultVal),
 
 	// Fill in any mappings that did not exist before
 	// Note: These should only be run as the very final step of all migrations. otherwise they will add items too early, and confuse old migrations

--- a/src/tv2_offtube_studio/migrations/mappings-defaults.ts
+++ b/src/tv2_offtube_studio/migrations/mappings-defaults.ts
@@ -1,15 +1,15 @@
 import { BlueprintMapping, BlueprintMappings, LookaheadMode, TSR } from '@sofie-automation/blueprints-integration'
-import { AbstractLLayerServerEnable, literal } from 'tv2-common'
-import { AbstractLLayer, GraphicLLayer } from 'tv2-constants'
-import * as _ from 'underscore'
 import {
+	AbstractLLayerServerEnable,
 	CasparPlayerClip,
 	CasparPlayerClipLoadingLoop,
-	OfftubeAbstractLLayer,
-	OfftubeAtemLLayer,
-	OfftubeCasparLLayer,
-	OfftubeSisyfosLLayer
-} from '../layers'
+	GetDSKMappings,
+	literal
+} from 'tv2-common'
+import { AbstractLLayer, GraphicLLayer } from 'tv2-constants'
+import * as _ from 'underscore'
+import { ATEMModel } from '../../types/atem'
+import { OfftubeAbstractLLayer, OfftubeAtemLLayer, OfftubeCasparLLayer, OfftubeSisyfosLLayer } from '../layers'
 
 const MAPPINGS_ABSTRACT: BlueprintMappings = {
 	core_abstract: literal<TSR.MappingAbstract & BlueprintMapping>({
@@ -448,34 +448,7 @@ const MAPPINGS_ATEM: BlueprintMappings = {
 		mappingType: TSR.MappingAtemType.MixEffect,
 		index: 0 // 0 = ME1
 	}),
-	[OfftubeAtemLLayer.AtemDSKGraphics]: literal<TSR.MappingAtem & BlueprintMapping>({
-		device: TSR.DeviceType.ATEM,
-		deviceId: 'atem0',
-		lookahead: LookaheadMode.NONE,
-		mappingType: TSR.MappingAtemType.DownStreamKeyer,
-		index: 0 // 0 = DSK1
-	}),
-	[OfftubeAtemLLayer.AtemDSK2]: literal<TSR.MappingAtem & BlueprintMapping>({
-		device: TSR.DeviceType.ATEM,
-		deviceId: 'atem0',
-		lookahead: LookaheadMode.NONE,
-		mappingType: TSR.MappingAtemType.DownStreamKeyer,
-		index: 1 // 1 = DSK2
-	}),
-	[OfftubeAtemLLayer.AtemDSK3]: literal<TSR.MappingAtem & BlueprintMapping>({
-		device: TSR.DeviceType.ATEM,
-		deviceId: 'atem0',
-		lookahead: LookaheadMode.NONE,
-		mappingType: TSR.MappingAtemType.DownStreamKeyer,
-		index: 2 // 2 = DSK3
-	}),
-	[OfftubeAtemLLayer.AtemDSK4]: literal<TSR.MappingAtem & BlueprintMapping>({
-		device: TSR.DeviceType.ATEM,
-		deviceId: 'atem0',
-		lookahead: LookaheadMode.NONE,
-		mappingType: TSR.MappingAtemType.DownStreamKeyer,
-		index: 3 // 3 = DSK4
-	}),
+	...GetDSKMappings(ATEMModel.PRODUCTION_STUDIO_4K_2ME),
 	[OfftubeAtemLLayer.AtemAuxClean]: literal<TSR.MappingAtem & BlueprintMapping>({
 		device: TSR.DeviceType.ATEM,
 		deviceId: 'atem0',

--- a/src/tv2_offtube_studio/migrations/util.ts
+++ b/src/tv2_offtube_studio/migrations/util.ts
@@ -57,27 +57,6 @@ export function ensureStudioConfig(
 	}
 }
 
-export function setConfigTo(versionStr: string, id: string, value: any) {
-	return literal<MigrationStepStudio>({
-		id: `config.valueSet.${id}`,
-		version: versionStr,
-		canBeRunAutomatically: true,
-		validate: (context: MigrationContextStudio) => {
-			// Optional mappings based on studio settings can be dropped here
-
-			const existing = context.getConfig(id)
-			if (!existing) {
-				return false
-			}
-
-			return !_.isEqual(existing, value)
-		},
-		migrate: (context: MigrationContextStudio) => {
-			context.setConfig(id, value)
-		}
-	})
-}
-
 export function renameStudioConfig(
 	version: string,
 	oldConfigName: string,

--- a/src/types/atem.ts
+++ b/src/types/atem.ts
@@ -50,3 +50,13 @@ export enum AtemSourceIndex {
 	Prg4 = 10040,
 	Prv4 = 10041
 }
+
+/**
+ * !! Not an exhaustive list !!
+ * !! Only contains ATEM models supported by / tested with these blueprints !!
+ */
+export enum ATEMModel {
+	PRODUCTION_STUDIO_4K_2ME = 'PRODUCTION_STUDIO_4K_2ME',
+	CONSTELLATION_8K_UHD_MODE = 'CONSTELLATION_8K_UHD',
+	CONSTELLATION_8K_8K_MODE = 'CONSTELLATION_8K_8K'
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,9 +287,9 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@sofie-automation/blueprints-integration@https://github.com/olzzon/tv-automation-server-core.git#dist_blueprints_integration20210323_1":
+"@sofie-automation/blueprints-integration@https://github.com/olzzon/tv-automation-server-core.git#dist_blueprints_integration20210324_1":
   version "1.16.1"
-  resolved "https://github.com/olzzon/tv-automation-server-core.git#0f151671d58f251779d556d5feb39bf5bd465f37"
+  resolved "https://github.com/olzzon/tv-automation-server-core.git#e9efa51e1b0999c353f30a4305c8e3f79acbda98"
   dependencies:
     moment "2.29.1"
     timeline-state-resolver-types "git+https://github.com/olzzon/tv-automation-state-timeline-resolver#dist_types20210323_1"


### PR DESCRIPTION
This PR aims to remove assumptions made about the shape of a studio from the DSK control logic. e.g. the AFVD blueprints currently assume that FULL and OVL graphics will always share a DSK and a key/fill SDI pair. This is not the case for Gallery Zero, and is not the case if AVFD has seperate OVL and FULL engines in the future.

To achieve this, the DSK config table has had the checkbox "Full graphic source" replaced with a multi-select dropdown of DSK "Roles", where the current available roles are: `jingle`, `overlay_graphics`, and `full_graphics`. This approach enables a few behaviours:
- We no longer assume anything about any DSK, in terms of which DSK number maps to a particular role.
- DSK mappings are now just `atem_dsk_x` and sourcelayers are `studio0_dsk_x_cmd`, rather than there being a special mapping for e.g. `atem_dsk_graphics` before.
- Any combination of DSK / key/fill pair sharing can be used. e.g. Jingle sharing with Full (although this may impose restrictions on what is possible to write in the script depending on the combination - not new to this PR).
- More roles can be added in the future without introducing new layer mappings / complexities to the blueprints.

Additionally this PR changes:
- Both AFVD and the QBox showstyles now share code for generating DSK adlibs + baseline.
- A DSK baseline/mappings/sourcelayers can be generated based on what model of ATEM is in use (could be expanded to other makes of mixer in the future). This aims to move studio blueprints towards defining a studio by defining the hardware in use, possibly entirely through settings.
- Adds support for correctly dispalying HTML-based graphics in Zero and AFVD-like galleries.

Note:
- For HTML Pilot-style graphics, we look for a DSK with the `full_graphics` role and use the Fill source as the PGM source. The alternative here would be a separate setting just for HTML graphics which doesn't feel right, it feels prone to errors. It would be great if we had a way to specify SDI roles/labels somewhere, then use those in this table... future work maybe.

Other future work:
- There is currently code duplication between AFVD and Q2 for how to display HTML Fulls, and Q2 still has no support for Viz Fulls. Work needed to find the overlap in studio control logic.
- A similar approach will likely work for AUXs... maybe even for M/Es, which could help with the previous point.